### PR TITLE
(MAINT) Set Hugo env to prod for GHP

### DIFF
--- a/.github/workflows/publish.site.yml
+++ b/.github/workflows/publish.site.yml
@@ -48,9 +48,12 @@ jobs:
           npm ls
           cd ..
       - name: Build the Site
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
         run: |
           cd ./Site
-          hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+          hugo --minify --baseURL "https://microsoft.github.io/Documentarian/"
           cd ..
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
# PR Summary

Prior to this change, the GitHub Action for building hugo did not specify an environment and appears to have built the site in dev mode. This change explicitly sets the build for prod.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
