### PR TITLE
(MAINT) Fix `Update-SourceDependency` in Documentarian.DevX

### DIFF
--- a/Source/Modules/Documentarian.DevX/Source/Public/Functions/General/Update-SourceDependency.ps1
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Functions/General/Update-SourceDependency.ps1
@@ -39,6 +39,7 @@ function Update-SourceDependency {
         "'$($_.SourceFile.FileInfo.FullName)'"
       ) -join ' '
       Write-Verbose $Message
+
       $_.SetReferencePreamble()
     }
   }


### PR DESCRIPTION
# PR Summary

Prior to this change:

1. The `WriteMungedContentWithReferencePreamble()` method in the **SourceReference** class didn't respect the file's original EOL characters or included copyright and license notices.
1. The `ResolveReferencePreamble()` method in the **SourceReference** class incorrectly set the relative path for required functions when the module was nested in a file path that included more than one folder segment named `Source` (case insensitive).
1. The **SourceFile** class didn't have properties for the file's original line endings, copyright notices, or license notices.

Because of this context, using the `Update-SourceDependency` cmdlet caused updated files to lose their notices, fail when loading their required functions, and have their EOL munged on Windows if it wasn't already set to CRLF.

This change:

1. Adds new properties and methods to the **SourceFile** class to handle EOL characters and notices.

   - The **LineEnding** property holds the original EOL definition of the source file.
   - The `GetLineEnding()` method inspects content to discover what EOL characters are used in it.
   - The `DefineLineEnding()` method uses `GetLineEnding()` and sets the resulting value for the **LineEnding** property on an instance of the class.
   - The **CopyrightNotices** property holds the list of copyright notices in a source file.
   - The static **CopyrightNoticePattern** property defines a default regular expression for finding copyright notices in a source file. It matches lines that begin with a comment (no leading whitespace) followed by the text `Copyright`.
   - The `FindCopyrightNotice()` method inspects content to discover copyright notices and return them as an array of strings.
   - The `DefineCopyrightNotice()` method uses `FindCopyrightNotice()` and sets the resulting value for the **CopyRightNotices** property on an instance of the class.
   - The **LicenseNotices** property holds the list of license notices in a source file.
   - The static **LicenseNoticePattern** property defines a default regular expression for finding license notices in a source file. It matches lines that begin with a comment (no leading whitespace) followed by the text `Licensed under`.
   - The `FindLicenseNotice()` method inspects content to discover license notices and return them as an array of strings.
   - The `DefineLicenseNotice()` method uses `FindLicenseNotice()` and sets the resulting value for the **LicenseNotices** property on an instance of the class.
   - The static `SplitContent()` method splits a string on on any line endings so each line can be handled separately. This new method is now used wherever the class previously split content with a regular expression for EOL characters.
1. Updates the `WriteMungedContentWithReferencePreamble()` method to use the new **LineEnding**, **CopyrightNotices**, and **LicenseNotices** properties defined on a **SourceFile**. It ensures that the EOL for the newly munged content is the same as the original file and that the notices are included before any other statements.
1. Updates the `ResolveReferencePreamble()` method to find the source folder for the processed file and build the correct path instead of the previous naive regex implementation.
1. Ensures that using the `Update-SourceDependency` cmdlet correctly updates dependencies without the previous side effects of stripping the copyright and license notices, munging the file's EOL, and writing the wrong path for required functions.


## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
