### PR TITLE
(MAINT) Add ModuleComposer & Build-ComposedModule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ Source/Styles/*
 !Source/Styles/Vocab/
 
 # Hugo ignores
-**/public
+site/public
+Source/Hugo/**/public
 **/resources/_gen
 **/.hugo_build.lock
 **/node_modules

--- a/Source/Modules/Documentarian.DevX/.DevX.jsonc
+++ b/Source/Modules/Documentarian.DevX/.DevX.jsonc
@@ -1,0 +1,39 @@
+// Documentarian.DevX JSON Configuration File
+{
+  "ManifestData": {
+    "RootModule": "Documentarian.DevX.psm1",
+    "ModuleVersion": "0.0.1",
+    "CompatiblePSEditions": "Core",
+    "GUID": "34628ac1-a222-4ae9-abb6-888ae5284410",
+    "Author": "PowerShell Docs Team",
+    "CompanyName": "Microsoft",
+    "Copyright": "(c) Microsoft. All rights reserved.",
+    "PowerShellVersion": "7.2",
+    "RequiredModules": [
+      "PowerShell-Yaml"
+    ],
+    "ScriptsToProcess": "Init.ps1",
+    "VariablesToExport": "*",
+    "Tags": [
+      "Development",
+      "Maintenance"
+    ],
+    "ProjectUri": "https://github.com/microsoft/Documentarian",
+    "LicenseUri": "https://github.com/microsoft/Documentarian/blob/main/LICENSE-CODE"
+  },
+  "ModuleCopyrightNotice": "Copyright (c) Microsoft Corporation.",
+  "ModuleLicenseNotice": "Licensed under the MIT License.",
+  "ModuleLineEnding": "\n",
+  "ModuleName": "Documentarian.DevX",
+  "ModuleVersion": "0.0.1",
+  "OutputFolderPath": "./[[ManifestData.ModuleVersion]]",
+  // "OutputInitScriptPath": "",
+  // "OutputManifestPath": "",
+  // "OutputPrivateModulePath": "",
+  // "OutputRootModulePath": "",
+  "SourceFolderPath": "./Source",
+  "SourceInitScriptPath": "./Source/Init.ps1"
+  // "SourceManifestPath": "./Manifest.psd1"
+  // "SourcePrivateFolderPath": "",
+  // "SourcePublicFolderPath": ""
+}

--- a/Source/Modules/Documentarian.DevX/.build.ps1
+++ b/Source/Modules/Documentarian.DevX/.build.ps1
@@ -18,31 +18,7 @@ param(
   $Configuration = 'Test'
 )
 
-$Script:Manifest = @{
-  RootModule           = 'Documentarian.DevX.psm1'
-  ModuleVersion        = '0.0.1'
-  CompatiblePSEditions = 'Core'
-  GUID                 = '34628ac1-a222-4ae9-abb6-888ae5284410'
-  Author               = 'PowerShell Docs Team'
-  CompanyName          = 'Microsoft'
-  Copyright            = '(c) Microsoft. All rights reserved.'
-  PowerShellVersion    = '7.2'
-  RequiredModules      = @(
-    'PowerShell-Yaml'
-  )
-  ScriptsToProcess     = 'Init.ps1'
-  VariablesToExport    = '*'
-  Tags                 = @(
-    'Development'
-    'Maintenance'
-  )
-  ProjectUri           = 'https://github.com/PowerShell/Documentarian.DevX'
-  LicenseUri           = 'https://github.com/PowerShell/Documentarian.DevX/blob/main/LICENSE'
-}
-
 $Script:SourceFolderPath = Join-Path -Path $PSScriptRoot -ChildPath 'Source'
-$Script:PrivateFolderPath = Join-Path -Path $Script:SourceFolderPath -ChildPath 'Private'
-$Script:PublicFolderPath = Join-Path -Path $Script:SourceFolderPath -ChildPath 'Public'
 
 $FunctionFinderParams = @{
   Path    = $Script:SourceFolderPath
@@ -60,111 +36,9 @@ foreach ($Function in $Functions) {
   . $Function.FullName
 }
 
-$Script:ModuleFolderPath = Join-Path -Path $PSScriptRoot -ChildPath $Script:Manifest.ModuleVersion
-$Script:RootModule = Join-Path -Path $Script:ModuleFolderPath -ChildPath 'Documentarian.DevX.psm1'
-$Script:ManifestPath = Join-Path -Path $Script:ModuleFolderPath -ChildPath 'Documentarian.DevX.psd1'
-
-$Script:PublicFunctions = [string[]]@()
-$Script:SourceFolders = [SourceFolder[]]@()
-
-$Script:InitScriptContent = @"
-<#
-  .SYNOPSIS
-    Initializes state for the module on load.
-  .DESCRIPTION
-    This script file initializes state for the Documentarian module to
-    make it easier to work with the classes, configuration, and enums.
-
-    It runs in the caller's session state when the module is loaded to
-    obviate the need to remember to call the ``using`` statement on the
-    module and ensures the public classes and enums are available.
-#>
-
-using module ./$(${Script:Manifest}.RootModule)
-"@
-
-task Clean {
-  if (Test-Path -Path $Script:ModuleFolderPath) {
-    Remove-Item -Path $Script:ModuleFolderPath -Recurse -Force
-  }
-
-  $null = New-Item -Path $Script:ModuleFolderPath -ItemType Directory -Force
-}
-
-task GetSourceFolders {
-  $SourceFinderParameters = @{
-    Preset        = 'All'
-    PublicFolder  = $Script:PublicFolderPath
-    PrivateFolder = $Script:PrivateFolderPath
-  }
-  $Script:SourceFolders = Get-SourceFolder @SourceFinderParameters
-
-  [string[]]$Script:PublicFunctions = $Script:SourceFolders
-  | Where-Object { $_.Scope -eq 'Public' -and $_.Category -eq 'Function' }
-  | ForEach-Object { Split-Path -Path $_.SourceFiles.FileInfo.FullName -LeafBase }
-}
-
 # Compose the Documentarian.DevX.psm1 file from source.
-task ComposeModule Clean, GetSourceFolders, {
-  $PrivateModuleFolders = $Script:SourceFolders
-  | Where-Object -FilterScript {
-    ($_.Category -ne 'Function') -and
-    ($_.Scope -eq 'Private') -and
-    ($_.SourceFiles.Count -gt 0)
-  }
-
-  $PublicModuleFolders = $Script:SourceFolders
-  | Where-Object -FilterScript {
-    ($_.DirectoryInfo.FullName -notin $PrivateModuleFolders.DirectoryInfo.FullName) -and
-    ($_.SourceFiles.Count -gt 0)
-  }
-
-  if ($PrivateModuleFolders) {
-    $PrivateModulePath = $Script:RootModule -replace 'psm1$', 'Private.psm1'
-    $UsingPrivateModuleStatement = "using module ./$(Split-Path -Leaf -Path $PrivateModulePath)"
-
-    Set-Content -Path $Script:RootModule -Value $UsingPrivateModuleStatement
-
-    $PrivateModuleFolders.SourceFiles.GetNonLocalUsingStatements()
-    | Select-Object -Unique
-    | Join-String -Separator ([System.Environment]::NewLine)
-    | Set-Content -Path $PrivateModulePath
-
-    $PrivateModuleFolders
-    | ForEach-Object { $_.ComposeSourceFiles().trim() }
-    | Join-String -Separator ([System.Environment]::NewLine * 2)
-    | Add-Content -Path $PrivateModulePath
-  }
-
-  $PublicModuleFolders.SourceFiles.GetNonLocalUsingStatements()
-  | Select-Object -Unique
-  | Join-String -Separator ([System.Environment]::NewLine)
-  | Add-Content -Path $Script:RootModule
-
-  $PublicModuleFolders
-  | ForEach-Object { $_.ComposeSourceFiles().trim() }
-  | Join-String -Separator ([System.Environment]::NewLine * 2)
-  | Add-Content -Path $Script:RootModule
-
-  $ExportStatement = @(
-    '$ExportableFunctions = @('
-    $Script:PublicFunctions | ForEach-Object { "  '$_'" }
-    ')'
-    'Export-ModuleMember -Alias * -Function $ExportableFunctions'
-  ) -join [System.Environment]::NewLine
-  Add-Content -Path $Script:RootModule -Value ([System.Environment]::NewLine + $ExportStatement)
-}
-
-task WriteManifest Clean, {
-  $Manifest = $Script:Manifest
-  $Manifest.Path = $Script:ManifestPath
-  $Manifest.FunctionsToExport = $Script:PublicFunctions
-  New-ModuleManifest @Manifest
-}
-
-task WriteInitScript {
-  $InitScriptPath = Join-Path -Path (Split-Path -Path $Script:ManifestPath) -ChildPath 'Init.ps1'
-  Set-Content -Path $InitScriptPath -Value $Script:InitScriptContent
+task ComposeModule {
+  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
 }
 
 task CheckDependencies {
@@ -172,4 +46,4 @@ task CheckDependencies {
 }
 
 # Default task composes the module and writes the manifest
-task . ComposeModule, WriteManifest, WriteInitScript
+task . ComposeModule

--- a/Source/Modules/Documentarian.DevX/Source/Init.ps1
+++ b/Source/Modules/Documentarian.DevX/Source/Init.ps1
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+  .SYNOPSIS
+    Initializes state for the module on load.
+  .DESCRIPTION
+    This script file initializes state for the Documentarian.DevX module
+    to make it easier to work with the module's classes, configuration,
+    and enums.
+
+    It runs in the caller's session state when the module is loaded to
+    obviate the need to remember to call the `using` statement on the
+    module and ensures the public classes and enums are available.
+#>

--- a/Source/Modules/Documentarian.DevX/Source/Public/Classes/.LoadOrder.jsonc
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Classes/.LoadOrder.jsonc
@@ -37,5 +37,10 @@
         "Name": "SourceReference",
         "IgnoreForBuild": false,
         "IgnoreForTest": false
+    },
+    {
+        "Name": "ModuleComposer",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
     }
 ]

--- a/Source/Modules/Documentarian.DevX/Source/Public/Classes/ModuleComposer.psm1
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Classes/ModuleComposer.psm1
@@ -1,0 +1,437 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ./SourceFolder.psm1
+
+#region    RequiredFunctions
+
+$SourceFolder = $PSScriptRoot
+while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
+  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+}
+$RequiredFunctions = @(
+  Resolve-Path -Path "$SourceFolder/Public/Functions/Ast/Get-Ast.ps1"
+  Resolve-Path -Path "$SourceFolder/Public/Functions/General/Get-SourceFolder.ps1"
+)
+foreach ($RequiredFunction in $RequiredFunctions) {
+  . $RequiredFunction
+}
+
+#endregion RequiredFunctions
+
+class ModuleComposer {
+  #region Configurable Settings
+
+  [string]    $ProjectRootFolderPath
+  [hashtable] $ManifestData
+  [string]    $ModuleCopyrightNotice
+  [string]    $ModuleLicenseNotice
+  [string]    $ModuleLineEnding
+  [string]    $ModuleName
+  [version]   $ModuleVersion
+  [string]    $OutputFolderPath
+  [string]    $OutputInitScriptPath
+  [string]    $OutputManifestPath
+  [string]    $OutputPrivateModulePath
+  [string]    $OutputRootModulePath
+  [string]    $SourceFolderPath
+  [string]    $SourceInitScriptPath
+  [string]    $SourceManifestPath
+  [string]    $SourcePrivateFolderPath
+  [string]    $SourcePublicFolderPath
+
+  #endregion Configurable Settings
+
+  #region Module Source Properties
+
+  [SourceFolder[]]$SourceFolders
+  [SourceFolder[]]$PrivateSourceFolders
+  [SourceFolder[]]$PublicSourceFolders
+  [string[]]$PublicFunctions
+
+  #endregion Module Source Properties
+
+  #region Composed Module Content Properties
+
+  [string]$InitScriptContent
+  [string]$PrivateModuleContent
+  [string]$RootModuleContent
+
+  #endregion Composed Module Content Properties
+
+  [string] GetUsingPrivateModuleStatement() {
+    $statement = if ([string]::IsNullOrEmpty($this.OutputPrivateModulePath)) {
+      ''
+    } else {
+      "using module ./$(Split-Path -Leaf -Path $this.OutputPrivateModulePath)"
+    }
+
+    return $statement
+  }
+
+  #region    Constructors
+  ModuleComposer () {
+    $this.Initialize()
+  }
+
+  ModuleComposer ([string]$ProjectRootFolderPath) {
+    $this.ProjectRootFolderPath = $ProjectRootFolderPath
+    $this.Initialize()
+  }
+
+  ModuleComposer(
+    [string]$ProjectRootFolderPath,
+    [System.Management.Automation.OrderedHashtable]$ConfigurationSettings
+  ) {
+    $this.ProjectRootFolderPath = $ProjectRootFolderPath
+
+    foreach ($SettingKey in $ConfigurationSettings.Keys) {
+      $Value = $ConfigurationSettings.$SettingKey
+
+      # String values can reference other setting keys wrapped in double square braces.
+      if ($Value -is [string]) {
+        while ($Value -match '\[\[(?<KeyName>\S+)\]\]') {
+          $ReplacementKey = $Matches.KeyName
+          $ReplacementValue = $ConfigurationSettings
+          foreach ($DotPathSegment in ($ReplacementKey -split '\.')) {
+            $ReplacementValue = $ReplacementValue.$DotPathSegment
+          }
+          if ($ReplacementValue) {
+            $Value = $Value -replace "\[\[$ReplacementKey\]\]", $ReplacementValue
+          } else {
+            $ErrorMessage = @(
+              "Specified setting reference value [[$ReplacementKey]] for setting $SettingKey,"
+              "but it didn't resolve to a non-null value. Is the $ReplacementKey setting"
+              'defined in .devx.jsonc?'
+            ) -join ' '
+            throw $ErrorMessage
+          }
+        }
+      }
+
+      # Path values may be relative to the project root folder. Terminate on incorrect source path
+      # values but not missing output paths, as the output folder may not exist yet.
+      if ($SettingKey -match 'Path$') {
+        try {
+          Push-Location -Path $this.ProjectRootFolderPath
+          $Value = Resolve-Path -Path $Value -ErrorAction Stop
+        } catch {
+          if ($SettingKey -match '^Output') {
+            $Value = $_.TargetObject
+          } else {
+            throw $_
+          }
+        } finally {
+          Pop-Location
+        }
+      }
+
+      # $MungedHash.$SettingKey = $Value
+      $this.$SettingKey = $Value
+    }
+
+    $this.Initialize()
+  }
+  #endregion Constructors
+
+  [void] Initialize() {
+    if ([string]::IsNullOrEmpty($this.ProjectRootFolderPath)) {
+      $this.ProjectRootFolderPath = Get-Location
+    }
+
+    if ([string]::IsNullOrEmpty($this.ModuleName)) {
+      $this.ModuleName = Split-Path -Leaf -Path $this.ProjectRootFolderPath
+    }
+
+    if ([string]::IsNullOrEmpty($this.SourceFolderPath)) {
+      $this.SourceFolderPath = Join-Path -Path $this.ProjectRootFolderPath -ChildPath 'Source'
+    }
+
+    if ([string]::IsNullOrEmpty($this.SourcePrivateFolderPath)) {
+      $this.SourcePrivateFolderPath = Join-Path -Path $this.SourceFolderPath -ChildPath 'Private'
+    }
+
+    if ([string]::IsNullOrEmpty($this.SourcePublicFolderPath)) {
+      $this.SourcePublicFolderPath = Join-Path -Path $this.SourceFolderPath -ChildPath 'Public'
+    }
+
+    if ([string]::IsNullOrEmpty($this.SourceInitScriptPath)) {
+      $this.SourceInitScriptPath = Join-Path -Path $this.SourceFolderPath -ChildPath 'Init.ps1'
+    }
+
+    if ([string]::IsNullOrEmpty($this.SourceManifestPath)) {
+      $this.SourceManifestPath = Join-Path -Path $this.SourceFolderPath -ChildPath 'Manifest.psd1'
+    }
+    if (Test-Path -Path $this.SourceManifestPath) {
+      $ManifestFileData = Import-PowerShellDataFile -Path $this.SourceManifestPath
+      if ($null -eq $this.ManifestData) {
+        $this.ManifestData = $ManifestFileData
+      } else {
+        foreach ($Key in $ManifestFileData.Keys) {
+          if ($Key -notin $this.ManifestData.Keys) {
+            $this.ManifestData.$Key = $ManifestFileData.$Key
+          } elseif ($ManifestFileData.$Key.GetType().BaseType.Name -eq 'Array') {
+            $this.ManifestData.$Key = $ManifestFileData.$key + $this.ManifestData.$Key
+            | Select-Object -Unique
+          }
+          # TODO: Handle hashtables?
+        }
+      }
+    } else {
+      $this.ManifestData ??= @{}
+    }
+
+    if ([string]::IsNullOrEmpty($this.ManifestData.ModuleVersion)) {
+      $this.ManifestData.ModuleVersion = '0.0.1'
+    }
+
+    if ([string]::IsNullOrEmpty($this.OutputFolderPath)) {
+      $OutputfolderPathParams = @{
+        Path      = $this.ProjectRootFolderPath
+        ChildPath = $this.ManifestData.ModuleVersion
+      }
+      $this.OutputFolderPath = Join-Path @OutputfolderPathParams
+    }
+
+    if ([string]::IsNullOrEmpty($this.OutputRootModulePath)) {
+      $OutputRootModulePathParams = @{
+        Path      = $this.OutputFolderPath
+        ChildPath = "$($this.ModuleName).psm1"
+      }
+      $this.OutputRootModulePath = Join-Path @OutputRootModulePathParams
+    }
+
+    if ([string]::IsNullOrEmpty($this.OutputManifestPath)) {
+      $OutputManifestPathParams = @{
+        Path      = $this.OutputFolderPath
+        ChildPath = "$($this.ModuleName).psd1"
+      }
+      $this.OutputManifestPath = Join-Path @OutputManifestPathParams
+    }
+
+
+    if ([string]::IsNullOrEmpty($this.OutputInitScriptPath)) {
+      $this.OutputInitScriptPath = Join-Path -Path $this.OutputFolderPath -ChildPath 'Init.ps1'
+    }
+
+    $this.InitializeSourceFolders()
+    $this.InitializePublicFunctions()
+
+    if ($this.PrivateSourceFolders.Count -and [string]::IsNullOrEmpty($this.OutputPrivateModulePath)) {
+      $this.OutputPrivateModulePath = $this.OutputRootModulePath -replace 'psm1$', 'Private.psm1'
+    }
+
+    $this.InitializeModuleLineEnding()
+  }
+
+  [void] InitializeModuleLineEnding() {
+    if ([string]::IsNullOrEmpty($this.ModuleLineEnding)) {
+      $LineEndings = $this.SourceFolders
+      | Select-Object -ExpandProperty SourceFiles
+      | Select-Object -ExpandProperty LineEnding -Unique
+
+      if ($LineEndings.Count -eq 1) {
+        $this.ModuleLineEnding = $LineEndings[0]
+      } else {
+        Write-Verbose 'Inconsistent line endings in module, using OS preference instead.'
+        $this.ModuleLineEnding = [System.Environment]::NewLine
+      }
+    }
+  }
+
+  [void] InitializeSourceFolders() {
+    $SourceFinderParameters = @{
+      Preset        = 'All'
+      PublicFolder  = $this.SourcePublicFolderPath
+      PrivateFolder = $this.SourcePrivateFolderPath
+    }
+    $this.SourceFolders = Get-SourceFolder @SourceFinderParameters
+
+    $this.PrivateSourceFolders = $this.SourceFolders
+    | Where-Object -FilterScript {
+      ($_.Category -ne 'Function') -and
+      ($_.Scope -eq 'Private') -and
+      ($_.SourceFiles.Count -gt 0)
+    }
+
+    $this.PublicSourceFolders = $this.SourceFolders
+    | Where-Object -FilterScript {
+      ($_.DirectoryInfo.FullName -notin $this.PrivateSourceFolders.DirectoryInfo.FullName) -and
+      ($_.SourceFiles.Count -gt 0)
+    }
+  }
+
+  [void] InitializePublicFunctions() {
+    if ($null -eq $this.SourceFolders) {
+      $this.InitializeSourceFolders()
+    }
+
+    $this.PublicFunctions = $this.SourceFolders
+    | Where-Object { $_.Scope -eq 'Public' -and $_.Category -eq 'Function' }
+    | ForEach-Object { Split-Path -Path $_.SourceFiles.FileInfo.FullName -LeafBase }
+  }
+
+  [void] CleanOutputFolder() {
+    if (Test-Path -Path $this.OutputFolderPath) {
+      Remove-Item -Path $this.OutputFolderPath -Recurse -Force
+    }
+  }
+
+  [void] CreateOutputFolder() {
+    $this.CleanOutputFolder()
+    New-Item -Path $this.OutputFolderPath -ItemType Directory -Force
+  }
+
+  [void] ComposePrivateModuleContent() {
+    if (!([string]::IsNullOrEmpty($this.OutputPrivateModulePath))) {
+      $ContentBuilder = New-Object -TypeName System.Text.StringBuilder
+
+      $this.PrivateSourceFolders.SourceFiles.GetNonLocalUsingStatements()
+      | Select-Object -Unique
+      | ForEach-Object -Process {
+        $null = $ContentBuilder.Append($_)
+        $null = $ContentBuilder.Append($this.ModuleLineEnding)
+      }
+
+      $this.PrivateSourceFolders
+      | ForEach-Object {
+        $null = $ContentBuilder.Append($_.ComposeSourceFiles().trim())
+        $null = $ContentBuilder.Append($this.ModuleLineEnding)
+        $null = $ContentBuilder.Append($this.ModuleLineEnding)
+      }
+
+      $this.PrivateModuleContent = $this.MungeComposedContent($ContentBuilder.ToString())
+    }
+  }
+
+  [void] ComposeRootModuleContent() {
+    $ContentBuilder = New-Object -TypeName System.Text.StringBuilder
+
+    # Add the using statement for the private module first if needed
+    if (!([string]::IsNullOrEmpty($this.OutputPrivateModulePath))) {
+      $null = $ContentBuilder.Append($this.GetUsingPrivateModuleStatement())
+      $null = $ContentBuilder.Append($this.ModuleLineEnding)
+    }
+
+    # Add non-local using statements before source definitions
+    $this.PublicSourceFolders.SourceFiles.GetNonLocalUsingStatements()
+    | Select-Object -Unique
+    | ForEach-Object -Process {
+      $null = $ContentBuilder.Append($_)
+      $null = $ContentBuilder.Append($this.ModuleLineEnding)
+    }
+
+    $null = $ContentBuilder.Append($this.ModuleLineEnding)
+
+    # Add source definitions
+    $this.PublicSourceFolders
+    | ForEach-Object {
+      $Source = $_.ComposeSourceFiles().trim()
+      $null = $ContentBuilder.Append($Source)
+      $null = $ContentBuilder.Append($this.ModuleLineEnding)
+      $null = $ContentBuilder.Append($this.ModuleLineEnding)
+    }
+
+    # Add the export statement
+    $null = $ContentBuilder.Append('$ExportableFunctions = @(').Append($this.ModuleLineEnding)
+    foreach ($PublicFunction in $this.PublicFunctions) {
+      $null = $ContentBuilder.Append("  '$PublicFunction'").Append($this.ModuleLineEnding)
+    }
+    $null = $ContentBuilder.Append(')').Append($this.ModuleLineEnding)
+    $null = $ContentBuilder.Append($this.ModuleLineEnding)
+    $null = $ContentBuilder.Append('Export-ModuleMember -Alias * -Function $ExportableFunctions')
+    $null = $ContentBuilder.Append($this.ModuleLineEnding)
+
+    $this.RootModuleContent = $this.MungeComposedContent($ContentBuilder.ToString())
+  }
+
+  hidden [string] TrimNotices([string]$Content) {
+    foreach ($Notice in @($this.ModuleCopyrightNotice, $this.ModuleLicenseNotice)) {
+      if (![string]::IsNullOrEmpty($Notice)) {
+        $Content = $Content -replace "#\s*$([regex]::escape($Notice))", ''
+      }
+    }
+    return $Content.trim()
+  }
+
+  hidden [string] MungeComposedContent([string]$Content) {
+    # Remove the module notices from the file. These global notices only need to
+    # be listed once at the top of the file.
+    $MungedContent = $this.TrimNotices($content)
+
+    # Munge non-standard newlines in case they slipped through.
+    $MungedContent = $MungedContent -replace '(\r\n|\r|\n)', $this.ModuleLineEnding
+
+    # Insert the notices before the munged content.
+    $MungedContent = @(
+      "# $($this.ModuleCopyrightNotice)"
+      "# $($this.ModuleLicenseNotice)"
+      ''
+      $MungedContent
+    ) -join $this.ModuleLineEnding
+
+    # Limit consecutive newlines to two.
+    $MungeExtraNewlinesPattern = "($([regex]::escape($this.ModuleLineEnding))){2,}"
+    $ReplacementLineBreak = $this.ModuleLineEnding * 2
+    $MungedContent = $MungedContent -replace $MungeExtraNewlinesPattern, $ReplacementLineBreak
+
+    # Trim any extra lines that slipped through and end with a final newline.
+    $MungedContent = $MungedContent.Trim() + $this.ModuleLineEnding
+
+    return $MungedContent
+  }
+
+  [void] ComposeInitScriptContent() {
+    $ContentBuilder = New-Object -TypeName System.Text.StringBuilder
+    $UsingStatement = "using module ./$(Split-Path -Leaf $this.OutputRootModulePath)"
+
+    if (
+      ![string]::IsNullOrEmpty($this.SourceInitScriptPath) -and
+      (Test-Path -Path $this.SourceInitScriptPath)
+    ) {
+      $InitAst = Get-Ast -Path $this.SourceInitScriptPath
+
+      $InitHelp = $InitAst.Ast.GetHelpContent()?.GetCommentBlock()
+      $InitHelp = $InitHelp -replace [System.Environment]::NewLine, $this.ModuleLineEnding
+      $null = $ContentBuilder.Append($InitHelp).Append($this.ModuleLineEnding)
+
+      $null = $ContentBuilder.Append($UsingStatement)
+      $null = $ContentBuilder.Append(($this.ModuleLineEnding * 2))
+
+      # Get the script content, trim the notices and comment based help.
+      $Content = Get-Content -Path $this.SourceInitScriptPath -Raw
+      $Content = $this.TrimNotices($Content)
+      $Content = $Content -replace '<#(\s|\S)+?#>', ''
+      $null = $ContentBuilder.Append($Content.Trim()).Append($this.ModuleLineEnding)
+    } else {
+      $null = $ContentBuilder.Append($UsingStatement)
+      $null = $ContentBuilder.Append(($this.ModuleLineEnding * 2))
+    }
+
+    $this.InitScriptContent = $this.MungeComposedContent($ContentBuilder.ToString())
+  }
+
+  [void] ExportComposedModule() {
+    $this.CleanOutputFolder()
+    $this.CreateOutputFolder()
+    $this.ComposePrivateModuleContent()
+    $this.ComposeRootModuleContent()
+    $this.ComposeInitScriptContent()
+
+    if ($this.PrivateModuleContent) {
+      $this.PrivateModuleContent
+      | Out-File -FilePath $this.OutputPrivateModulePath -Encoding utf8 -NoNewline
+    }
+
+    $this.RootModuleContent
+    | Out-File -FilePath $this.OutputRootModulePath -Encoding utf8 -NoNewline
+
+    $this.InitScriptContent
+    | Out-File -FilePath $this.OutputInitScriptPath -Encoding utf8 -NoNewline
+
+    $ManifestParameters = $this.ManifestData
+    $ManifestParameters.Path = $this.OutputManifestPath
+    $ManifestParameters.FunctionsToExport = $this.PublicFunctions
+    New-ModuleManifest @ManifestParameters
+  }
+}

--- a/Source/Modules/Documentarian.DevX/Source/Public/Functions/General/Build-ComposedModule.ps1
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Functions/General/Build-ComposedModule.ps1
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../../Classes/ModuleComposer.psm1
+
+function Build-ComposedModule {
+  [CmdletBinding(DefaultParameterSetName = 'WithConfigurationFile')]
+  param(
+    [string] $ProjectRootFolderPath,
+
+    [Parameter(ParameterSetName = 'WithConfigurationFile')]
+    [string] $ConfigurationFilePath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [hashtable] $ManifestData,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $ModuleCopyrightNotice,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $ModuleLicenseNotice,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $ModuleName,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [version] $ModuleVersion,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $OutputFolderPath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $OutputInitScriptPath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $OutputManifestPath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $OutputPrivateModulePath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $OutputRootModulePath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $SourceFolderPath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $SourceInitScriptPath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $SourceManifestPath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $SourcePrivateFolderPath,
+
+    [Parameter(ParameterSetName = 'WithOptionValues')]
+    [string] $SourcePublicFolderPath
+  )
+
+  process {
+    if ([string]::IsNullOrEmpty($ProjectRootFolderPath)) {
+      [string]$ProjectRootFolderPath = Get-Location
+    }
+    Write-Verbose "Using project root folder path: $ProjectRootFolderPath"
+
+    if ($PSCmdlet.ParameterSetName -eq 'WithConfigurationFile') {
+      if ($ConfigurationFilePath) {
+        Write-Verbose "Using specified configuration file path: $ConfigurationFilePath"
+        $ConfigurationSettings = Get-Content -Raw -Path $ConfigurationFilePath
+        | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+      } else {
+        $ConfigurationFilePath = Join-Path -Path $ProjectRootFolderPath -ChildPath '.DevX.jsonc'
+        Write-Verbose "Checking for default configuration file path: $ConfigurationFilePath"
+        if (Test-Path -Path $ConfigurationFilePath) {
+          $ConfigurationSettings = Get-Content -Raw -Path $ConfigurationFilePath
+          | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        }
+      }
+    } else {
+      $ConfigurationSettings = @{}
+      $OptionKeys = $PSBoundParameters.Keys
+      | Where-Object -FilterScript { $_ -ne 'ProjectRootFolderPath' }
+
+      foreach ($Key in $OptionKeys) {
+        $ConfigurationSettings = $PSBoundParameters.$Key
+      }
+    }
+
+    if ($ConfigurationSettings) {
+      Write-Verbose "Composing with settings from $ConfigurationFilePath"
+      [ModuleComposer]$Composer = [ModuleComposer]::New(
+        $ProjectRootFolderPath,
+        $ConfigurationSettings
+      )
+    } else {
+      Write-Verbose 'Composing with default settings'
+      [ModuleComposer]$Composer = [ModuleComposer]::New($ProjectRootFolderPath)
+    }
+
+    Write-Verbose "Compsing module $($Composer.ModuleName) with settings:"
+    Write-Verbose "`tProjectRootFolderPath:   $($Composer.ProjectRootFolderPath)"
+    Write-Verbose "`tManifestData:            $($Composer.ManifestData | ConvertTo-Json)"
+    Write-Verbose "`tModuleCopyrightNotice:   $($Composer.ModuleCopyrightNotice)"
+    Write-Verbose "`tModuleLicenseNotice:     $($Composer.ModuleLicenseNotice)"
+    Write-Verbose "`tModuleName:              $($Composer.ModuleName)"
+    Write-Verbose "`tModuleVersion:           $($Composer.ModuleVersion)"
+    Write-Verbose "`tOutputFolderPath:        $($Composer.OutputFolderPath)"
+    Write-Verbose "`tOutputInitScriptPath:    $($Composer.OutputInitScriptPath)"
+    Write-Verbose "`tOutputManifestPath:      $($Composer.OutputManifestPath)"
+    Write-Verbose "`tOutputPrivateModulePath: $($Composer.OutputPrivateModulePath)"
+    Write-Verbose "`tOutputRootModulePath:    $($Composer.OutputRootModulePath)"
+    Write-Verbose "`tSourceFolderPath:        $($Composer.SourceFolderPath)"
+    Write-Verbose "`tSourceInitScriptPath:    $($Composer.SourceInitScriptPath)"
+    Write-Verbose "`tSourceManifestPath:      $($Composer.SourceManifestPath)"
+    Write-Verbose "`tSourcePrivateFolderPath: $($Composer.SourcePrivateFolderPath)"
+    Write-Verbose "`tSourcePublicFolderPath:  $($Composer.SourcePublicFolderPath)"
+    $Composer.ExportComposedModule()
+  }
+}

--- a/Source/Modules/Documentarian/.DevX.jsonc
+++ b/Source/Modules/Documentarian/.DevX.jsonc
@@ -1,0 +1,39 @@
+// Documentarian.DevX JSON Configuration File
+{
+  "ManifestData": {
+    "RootModule": "Documentarian.psm1",
+    "ModuleVersion": "0.0.1",
+    "CompatiblePSEditions": "Core",
+    "GUID": "2422ec90-815c-4c1d-8ec1-4c9b082f2909",
+    "Author": "PowerShell Docs Team",
+    "CompanyName": "Microsoft",
+    "Copyright": "(c) Microsoft. All rights reserved.",
+    "PowerShellVersion": "7.2",
+    "RequiredModules": [
+      "PowerShell-Yaml"
+    ],
+    "ScriptsToProcess": "Init.ps1",
+    "VariablesToExport": "*",
+    "Tags": [
+      "Markdown",
+      "Documentation"
+    ],
+    "ProjectUri": "https://github.com/microsoft/Documentarian",
+    "LicenseUri": "https://github.com/microsoft/Documentarian/blob/main/LICENSE-CODE"
+  },
+  "ModuleCopyrightNotice": "Copyright (c) Microsoft Corporation.",
+  "ModuleLicenseNotice": "Licensed under the MIT License.",
+  "ModuleLineEnding": "\n",
+  "ModuleName": "Documentarian",
+  "ModuleVersion": "0.0.1",
+  "OutputFolderPath": "./[[ManifestData.ModuleVersion]]",
+  // "OutputInitScriptPath": "",
+  // "OutputManifestPath": "",
+  // "OutputPrivateModulePath": "",
+  // "OutputRootModulePath": "",
+  "SourceFolderPath": "./Source",
+  "SourceInitScriptPath": "./Source/Init.ps1"
+  // "SourceManifestPath": "./Manifest.psd1"
+  // "SourcePrivateFolderPath": "",
+  // "SourcePublicFolderPath": ""
+}

--- a/Source/Modules/Documentarian/.build.ps1
+++ b/Source/Modules/Documentarian/.build.ps1
@@ -4,7 +4,6 @@
 #requires -Version 7.2
 #requires -Module InvokeBuild
 #requires -Module Documentarian.DevX
-using module ../Documentarian.DevX
 
 <#
   .SYNOPSIS
@@ -16,150 +15,9 @@ param(
   $Configuration = 'Test'
 )
 
-$Script:ModuleName = 'Documentarian'
-$Script:Manifest = @{
-  RootModule           = "$Script:ModuleName.psm1"
-  ModuleVersion        = '0.0.1'
-  CompatiblePSEditions = 'Core'
-  GUID                 = '2422ec90-815c-4c1d-8ec1-4c9b082f2909'
-  Author               = 'PowerShell Docs Team'
-  CompanyName          = 'Microsoft'
-  Copyright            = '(c) Microsoft. All rights reserved.'
-  PowerShellVersion    = '7.2'
-  RequiredModules      = @(
-    'PowerShell-Yaml'
-  )
-  ScriptsToProcess     = 'Init.ps1'
-  FunctionsToExport    = $Script:PublicFunctions
-  VariablesToExport    = '*'
-  Tags                 = @(
-    'Markdown'
-    'Documentation'
-  )
-  ProjectUri           = 'https://github.com/PowerShell/Documentarian'
-  LicenseUri           = 'https://github.com/PowerShell/Documentarian/blob/main/LICENSE'
-}
-
-$Script:SourceFolderPath = Join-Path -Path $PSScriptRoot -ChildPath 'Source'
-$Script:PrivateFolderPath = Join-Path -Path $Script:SourceFolderPath -ChildPath 'Private'
-$Script:PublicFolderPath = Join-Path -Path $Script:SourceFolderPath -ChildPath 'Public'
-
-$FunctionFinderParams = @{
-  Path    = $Script:SourceFolderPath
-  Recurse = $true
-  Include = '*.ps1'
-  Exclude = '*.Tests.ps1'
-}
-
-foreach ($Function in (Get-ChildItem @FunctionFinderParams)) {
-  . $Function.FullName
-}
-
-$Script:ModuleFolderPath = Join-Path -Path $PSScriptRoot -ChildPath $Script:Manifest.ModuleVersion
-$Script:RootModule = Join-Path -Path $Script:ModuleFolderPath -ChildPath "$Script:ModuleName.psm1"
-$Script:ManifestPath = Join-Path -Path $Script:ModuleFolderPath -ChildPath "$Script:ModuleName.psd1"
-
-$Script:PublicFunctions = [string[]]@()
-$Script:SourceFolders = [SourceFolder[]]@()
-
-$Script:InitScriptContent = @"
-<#
-  .SYNOPSIS
-    Initializes state for the module on load.
-  .DESCRIPTION
-    This script file initializes state for the Documentarian module to
-    make it easier to work with the classes, configuration, and enums.
-
-    It runs in the caller's session state when the module is loaded to
-obviate the need to remember to call the ``using`` statement on the
-Get-module and ensures the public classes and enums are available.
-#>
-
-using module ./$(${Script:Manifest}.RootModule)
-"@
-
-task Clean {
-  if (Test-Path -Path $Script:ModuleFolderPath) {
-    Remove-Item -Path $Script:ModuleFolderPath -Recurse -Force
-  }
-
-  $null = New-Item -Path $Script:ModuleFolderPath -ItemType Directory -Force
-}
-
-task GetSourceFolders {
-  $SourceFinderParameters = @{
-    Preset        = 'All'
-    PublicFolder  = $Script:PublicFolderPath
-    PrivateFolder = $Script:PrivateFolderPath
-  }
-  $Script:SourceFolders = Get-SourceFolder @SourceFinderParameters
-
-  [string[]]$Script:PublicFunctions = $Script:SourceFolders
-  | Where-Object { $_.Scope -eq 'Public' -and $_.Category -eq 'Function' }
-  | ForEach-Object { Split-Path -Path $_.SourceFiles.FileInfo.FullName -LeafBase }
-}
-
 # Compose the Documentarian.DevX.psm1 file from source.
-task ComposeModule Clean, GetSourceFolders, {
-  $PrivateModuleFolders = $Script:SourceFolders
-  | Where-Object -FilterScript {
-    ($_.Category -ne 'Function') -and
-    ($_.Scope -eq 'Private') -and
-    ($_.SourceFiles.Count -gt 0)
-  }
-
-  $PublicModuleFolders = $Script:SourceFolders
-  | Where-Object -FilterScript {
-    ($_.DirectoryInfo.FullName -notin $PrivateModuleFolders.DirectoryInfo.FullName) -and
-    ($_.SourceFiles.Count -gt 0)
-  }
-
-  if ($PrivateModuleFolders) {
-    $PrivateModulePath = $Script:RootModule -replace 'psm1$', 'Private.psm1'
-    $UsingPrivateModuleStatement = "using module ./$(Split-Path -Leaf -Path $PrivateModulePath)"
-
-    Set-Content -Path $Script:RootModule -Value $UsingPrivateModuleStatement
-
-    $PrivateModuleFolders.SourceFiles.GetNonLocalUsingStatements()
-    | Select-Object -Unique
-    | Join-String -Separator ([System.Environment]::NewLine)
-    | Set-Content -Path $PrivateModulePath
-
-    $PrivateModuleFolders
-    | ForEach-Object { $_.ComposeSourceFiles().trim() }
-    | Join-String -Separator ([System.Environment]::NewLine * 2)
-    | Add-Content -Path $PrivateModulePath
-  }
-
-  $PublicModuleFolders.SourceFiles.GetNonLocalUsingStatements()
-  | Select-Object -Unique
-  | Join-String -Separator ([System.Environment]::NewLine)
-  | Add-Content -Path $Script:RootModule
-
-  $PublicModuleFolders
-  | ForEach-Object { $_.ComposeSourceFiles().trim() }
-  | Join-String -Separator ([System.Environment]::NewLine * 2)
-  | Add-Content -Path $Script:RootModule
-
-  $ExportStatement = @(
-    '$ExportableFunctions = @('
-    $Script:PublicFunctions | ForEach-Object { "  '$_'" }
-    ')'
-    'Export-ModuleMember -Alias * -Function $ExportableFunctions'
-  ) -join [System.Environment]::NewLine
-  Add-Content -Path $Script:RootModule -Value ([System.Environment]::NewLine + $ExportStatement)
-}
-
-task WriteManifest Clean, {
-  $Manifest = $Script:Manifest
-  $Manifest.Path = $Script:ManifestPath
-  $Manifest.FunctionsToExport = $Script:PublicFunctions
-  New-ModuleManifest @Manifest
-}
-
-task WriteInitScript {
-  $InitScriptPath = Join-Path -Path (Split-Path -Path $Script:ManifestPath) -ChildPath 'Init.ps1'
-  Set-Content -Path $InitScriptPath -Value $Script:InitScriptContent
+task ComposeModule {
+  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
 }
 
 task CheckDependencies {
@@ -167,4 +25,4 @@ task CheckDependencies {
 }
 
 # Default task composes the module and writes the manifest
-task . ComposeModule, WriteManifest, WriteInitScript
+task . ComposeModule

--- a/Source/Modules/Documentarian/Source/Init.ps1
+++ b/Source/Modules/Documentarian/Source/Init.ps1
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+  .SYNOPSIS
+    Initializes state for the module on load.
+  .DESCRIPTION
+    This script file initializes state for the Documentarian module to
+    make it easier to work with the module's classes, configuration, and
+    enums.
+
+    It runs in the caller's session state when the module is loaded to
+    obviate the need to remember to call the `using` statement on the
+    module and ensures the public classes and enums are available.
+#>


### PR DESCRIPTION
# PR Summary

Prior to this change, composing modules from source required several steps in the Build script definition.

This change pulls the logic into the module itself and exposes it via the new **ModuleComposer** class (for controlling how a module is composed) and `Build-ComposedModule` cmdlet (for ease of use).

Todo:

- [x] Handle license and copyright notices better
- [x] Parse the `init` script to have the file comments before the using statement, then any other code.
- [x] Clarify handling for ManifestData
- [x] Convert build functionality of the **Documentarian** module

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
