### PR TITLE
(GH-16) Add `Get-DocumentLink`

### DIFF
--- a/Source/Modules/Documentarian/Source/Private/Functions/New-ParsedDocument.ps1
+++ b/Source/Modules/Documentarian/Source/Private/Functions/New-ParsedDocument.ps1
@@ -37,6 +37,8 @@ function New-ParsedDocument {
     }
     $Document.Body = $Body
 
+    $Document.ParseLinksFromBody()
+
     $Document
   }
 }

--- a/Source/Modules/Documentarian/Source/Public/Classes/.LoadOrder.jsonc
+++ b/Source/Modules/Documentarian/Source/Public/Classes/.LoadOrder.jsonc
@@ -9,6 +9,26 @@
     //     "IgnoreForTest": false
     // }
     {
+        "Name": "ParsingPatterns",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "Position",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "DocumentLink",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "LinkKindTransformAttribute",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
         "Name": "ParsedDocument",
         "IgnoreForBuild": false,
         "IgnoreForTest": false

--- a/Source/Modules/Documentarian/Source/Public/Classes/DocumentLink.psm1
+++ b/Source/Modules/Documentarian/Source/Public/Classes/DocumentLink.psm1
@@ -1,0 +1,351 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Enums/LinkKind.psm1
+using module ./Position.psm1
+using module ./ParsingPatterns.psm1
+
+class DocumentLink {
+  [LinkKind] $Kind
+  [string]   $Text
+  [uri]      $Destination
+  [string]   $Title
+  [string]   $ReferenceID
+  [Position] $Position
+  [string]   $Markdown
+
+  # Shorthand method for determining if this link is for an image
+  [bool] IsImage() {
+    return $this.Kind.ToString() -match '^Image'
+  }
+
+  # Shorthand method for determining if this link is for text
+  [bool] IsText() {
+    return $this.Kind.ToString() -match '^Text'
+  }
+
+  # Shorthand method for determining if this link has a reference
+  [bool] HasReference() {
+    return $this.Kind.ToString() -match 'Reference$'
+  }
+
+  [bool] IsSelfReferential() {
+    return $this.Kind.ToString() -match 'SelfReference$'
+  }
+
+  # Shorthand method for determining if this link is a reference
+  [bool] IsReference() {
+    return $this.Kind.ToString() -match '^Reference'
+  }
+
+  DocumentLink() {
+    # Re-defined to support alternate constructors
+  }
+
+  # Generate a document link from a match group for [ParsingPatterns]::Link
+  DocumentLink([System.Text.RegularExpressions.Group]$LinkMatch) {
+    [DocumentLink]::New($LinkMatch, 0)
+  }
+
+  # Generate a document link from a match group for [ParsingPatterns]::Link
+  DocumentLink([System.Text.RegularExpressions.Group]$LinkMatch, [int]$LineNumber) {
+    $this.Position = [Position]@{
+      FileInfo    = $null
+      LineNumber  = $LineNumber
+      StartColumn = $LinkMatch.Index + 1
+    }
+    $this.Text = [DocumentLink]::TrimSquareBrackets(
+      $LinkMatch.Groups.Where({ $_.Name -eq 'Text' }).Value
+    )
+    $this.Destination = $LinkMatch.Groups.Where({ $_.Name -eq 'Destination' }).Value
+    $this.Title = $LinkMatch.Groups.Where({ $_.Name -eq 'Title' }).Value
+    $this.ReferenceID = [DocumentLink]::TrimSquareBrackets(
+      $LinkMatch.Groups.Where({ $_.Name -eq 'ReferenceID' }).Value
+    )
+    $this.Markdown = $LinkMatch.Value
+
+    $IsImage = $LinkMatch.Groups.Where({ $_.Name -eq 'IsImage' }).Value -eq '!'
+    $IsInline = ![string]::IsNullOrWhiteSpace($this.Destination)
+    $HasReference = ![string]::IsNullOrWhiteSpace($this.ReferenceID)
+
+    if ($IsImage -and $IsInline) {
+      $this.Kind = [LinkKind]::ImageInline
+    } elseif ($IsImage -and $HasReference) {
+      $this.Kind = [LinkKind]::ImageUsingReference
+    } elseif ($IsImage) {
+      $this.Kind = [LinkKind]::ImageSelfReference
+    } elseif ($IsInline) {
+      $this.Kind = [LinkKind]::TextInline
+    } elseif ($HasReference) {
+      $this.Kind = [LinkKind]::TextUsingReference
+    } else {
+      $this.Kind = [LinkKind]::TextSelfReference
+    }
+  }
+
+  # Trim square brackets when using balance groups, like to find text and reference IDs
+  hidden static [string] TrimSquareBrackets([string]$Text) {
+    if ($Text -match '^\[(?<Inner>.*)\]$') {
+      return $Matches.Inner
+    }
+
+    return $Text
+  }
+
+  # Parses a file's content for Markdown links, parsing one line at a time to support ignoring any
+  # links in multiline codeblocks or comments, and ensuring the returned objects have the FileInfo
+  # property defined with the input file's values.
+  static [DocumentLink[]] Parse([System.IO.FileInfo]$FileInfo) {
+    $Content = Get-Content -Raw -Path $FileInfo.FullName
+    [DocumentLink[]]$Links = [DocumentLink]::Parse($Content)
+    | ForEach-Object -Process {
+      # Add the file info to each link
+      $_.Position.FileInfo = $FileInfo
+      # Emit the link for the list
+      $_
+    }
+
+    return $Links
+  }
+
+  # Parses an arbitrary block of text for Markdown links, parsing one line at a time to support
+  # ignoring any links in multiline codeblocks or comments.
+  static [DocumentLink[]] Parse([string]$Markdown) {
+    [DocumentLink[]]$Links = @()
+    [DocumentLink[]]$DiscoveredLinks = @()
+    $Lines = $Markdown -split '\r?\n|`r'
+    $InCodeFence = $false    # This is set to true when a code fence opens to ignore lines til close
+    $CodeFenceClose = $null  # This is defined when a code fence is found and nulled when closed
+    $InCommentBlock = $false # This is set to true when a comment block opens without closing
+    for ($i = 1; $i -le $Lines.Count ; $i++) {
+      $CommentBlocks = @()       # This holds the enclosed comment blocks for a line
+      $IgnoreAfterIndex = $null  # Points to a comment block that doesn't close on this line
+      $IgnoreBeforeIndex = $null # Points to closing of a multi-line comment block
+      $LinkMatches = $null       # Holds discovered links on this line
+      $Line = $Lines[$i - 1]     # Editors/humans use a 1-index array for file lines
+
+      # Before we process anything else, check if we're in a code fence and closing it
+      if ($InCodeFence) {
+        if ($Line -eq $CodeFenceClose) {
+          $InCodeFence = $false
+          $CodeFenceClose = $null
+        }
+        # Regardless whether this line closes the code fence, no valid links can be here.
+        continue
+      } elseif ($InCommentBlock) {
+        # If we're not in a code fence, we might be in a comment block and need to see if it closes.
+        # If it does, we need to mark the index so we ignore links before the closure.
+        if ($Line -match [ParsingPatterns]::ClosingMultiLineHtmlComment) {
+          $ClosingMatch = $Matches
+          $InCommentBlock = $false
+          $IgnoreBeforeIndex = ($ClosingMatch.InComments + $ClosingMatch.CloseComment).Length
+        }
+      }
+
+      # Look for new HTML comments. We need to capture fully enclosed comments and mark any unclosed
+      # comments so we can ignore links in comments. We can have any number of comments on a line.
+      $HtmlCommentMatches = [regex]::Matches($Line, [ParsingPatterns]::HtmlCommentBlock)
+      if ($HtmlCommentMatches.Count) {
+        $CommentBlocks = $HtmlCommentMatches.Groups
+        | Where-Object { $_.Name -eq 'InComments' }
+        | Select-Object -ExpandProperty Value
+        if ($CommentBlocks) {
+        }
+        $UnclosedHtmlComment = $HtmlCommentMatches
+        | Where-Object {
+          $_.Groups | Where-Object {
+            $_.Name -eq 'CloseComment' -and (-not $_.Success)
+          }
+        } | Select-Object -First 1
+        if ($UnclosedHtmlComment) {
+          $IgnoreAfterIndex = $UnclosedHtmlComment.Index
+          $InCommentBlock = $true
+        }
+      }
+
+      # If the line opens a code fence, capture the closing pattern and continue
+      # if ($Line -match [DocumentLink]::OpenCodeFencePattern) {
+      if ($Line -match [ParsingPatterns]::OpenCodeFence) {
+        $InCodeFence = $true
+        $CodeFenceClose = @(
+          $Matches.Lead -replace '([0-9]|\.|-|\+|\*)', ' '
+          $Matches.Fence
+        ) -join ''
+        continue
+      }
+
+      # Check for link references first - less expensive and no valid links follow them.
+      if ($Line -match [ParsingPatterns]::LinkReferenceDefinition) {
+        $ReferenceMatchInfo = $Matches
+        $FullMatch = $ReferenceMatchInfo.0
+        if ([ParsingPatterns]::NotInsideInlineCode($Line, $FullMatch)) {
+          $Properties = @{
+            Position    = [Position]@{
+              LineNumber  = $i
+              StartColumn = $ReferenceMatchInfo.Lead.Length
+            }
+            ReferenceID = [DocumentLink]::TrimSquareBrackets($ReferenceMatchInfo.ReferenceID)
+            Destination = $ReferenceMatchInfo.Destination
+            Title       = $ReferenceMatchInfo.Title
+            Markdown    = $FullMatch
+            Kind        = [LinkKind]::ReferenceDefinition
+          }
+
+          $DiscoveredLinks += [DocumentLink]$Properties
+        }
+
+        # Reset before next line
+        $ReferenceMatchInfo = $null
+        continue
+      }
+
+      # Find all links in the line, ignoring them if in comment blocks or code
+      if ($LinkMatches = [regex]::Matches($Line, [ParsingPatterns]::Link)) {
+        foreach ($LinkMatch in $LinkMatches) {
+          $FullMatch = $LinkMatch.Value
+          $Index = $LinkMatch.Index
+          $NotInsideComment = $true
+
+          # If there was an unclosed comment block on this line, ignore links after it started
+          if ($IgnoreAfterIndex -and ($Index -gt $IgnoreAfterIndex)) {
+            $NotInsideComment = $false
+          }
+
+          # If this line closed a multi-line comment block, ignore links before it closed
+          if ($IgnoreBeforeIndex -and ($Index -le $IgnoreBeforeIndex)) {
+            $NotInsideComment = $false
+          }
+
+          # If this line had closed comment blocks, ignore links inside them
+          foreach ($Block in $CommentBlocks) {
+            if ($Block -match [regex]::Escape($FullMatch)) {
+              $NotInsideComment = $false
+            }
+          }
+
+          $NotInsideInlineCode = [ParsingPatterns]::NotInsideInlineCode($Line, $FullMatch)
+          if ($NotInsideComment -and $NotInsideInlineCode) {
+            $Link = [DocumentLink]::New($LinkMatch, $i)
+            $DiscoveredLinks += $Link
+            # Look for nested links, setting their position relative to their parent
+            if (![string]::IsNullOrWhiteSpace($Link.Text)) {
+              if ($NestedLinks = [DocumentLink]::ParseNested($Link.Text, 1, 5)) {
+                foreach ($NestedLink in $NestedLinks) {
+                  $NestedLink.Position.LineNumber = $Link.Position.LineNumber
+                  $NestedLink.Position.StartColumn += $Link.Position.StartColumn
+                  $DiscoveredLinks += $NestedLink
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    # Need to discard self-reference links without a definition - they're technically
+    # not links at all.
+    $ReferenceDefinitions = $DiscoveredLinks | Where-Object -FilterScript { $_.IsReference() }
+    foreach ($Link in $DiscoveredLinks) {
+      if (!$Link.IsSelfReferential() -or ($Link.Text -in $ReferenceDefinitions.ReferenceID)) {
+        $Links += $Link
+      }
+    }
+
+    return $Links
+  }
+
+  hidden static [DocumentLink[]] ParseNested([string]$LinkText, [int]$Depth, [int]$MaxDepth) {
+    [DocumentLink[]]$Links = @()
+    $CommentBlocks = @()
+
+    if ($Depth -gt $MaxDepth) {
+      return $Links
+    }
+
+    # Look for new HTML comments. We need to capture fully enclosed comments and mark any unclosed
+    # comments so we can ignore links in comments. We can have any number of comments on a line.
+    $HtmlCommentMatches = [regex]::Matches($LinkText, [ParsingPatterns]::HtmlCommentBlock)
+    if ($HtmlCommentMatches.Count) {
+      $CommentBlocks = $HtmlCommentMatches.Groups
+      | Where-Object { $_.Name -eq 'InComments' }
+      | Select-Object -ExpandProperty Value
+    }
+
+    # Find all links in the line, ignoring them if in comment blocks or code
+    if ($LinkMatches = [regex]::Matches($LinkText, [ParsingPatterns]::Link)) {
+      foreach ($LinkMatch in $LinkMatches) {
+        $FullMatch = $LinkMatch.Value
+        $NotInsideComment = $true
+
+        # If this line had closed comment blocks, ignore links inside them
+        foreach ($Block in $CommentBlocks) {
+          if ($Block -match [regex]::Escape($FullMatch)) {
+            $NotInsideComment = $false
+          }
+        }
+
+        $NotInsideInlineCode = [ParsingPatterns]::NotInsideInlineCode($LinkText, $FullMatch)
+        if ($NotInsideComment -and $NotInsideInlineCode) {
+          $Link = [DocumentLink]::New($LinkMatch, 0)
+          $Links += $Link
+          # Look for nested links, setting their position relative to their parent
+          if (![string]::IsNullOrWhiteSpace($Link.Text)) {
+            if ($NestedLinks = [DocumentLink]::ParseNested($Link.Text, ($Depth + 1), $MaxDepth)) {
+              foreach ($NestedLink in $NestedLinks) {
+                $NestedLink.Position.LineNumber = $Link.Position.LineNumber
+                $NestedLink.Position.StartColumn += $Link.Position.StartColumn
+                $Links += $NestedLink
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return $Links
+  }
+
+  hidden static [DocumentLink[]] FilterForInlineLinks([DocumentLink[]]$Links) {
+    return $Links.Where({ -not ($_.HasReference() -or $_.IsReference()) })
+  }
+
+  hidden static [DocumentLink[]] FilterForReferenceLinks([DocumentLink[]]$Links) {
+    return $Links.Where({ $_.HasReference() })
+  }
+
+  hidden static [DocumentLink[]] FilterForSelfReferentialLinks([DocumentLink[]]$Links) {
+    return $Links.Where({ $_.IsSelfReferential() })
+  }
+
+  hidden static [DocumentLink[]] FilterForReferenceDefinitions([DocumentLink[]]$Links) {
+    return $Links.Where({ $_.IsReference() })
+  }
+
+  hidden static [DocumentLink[]] FilterForReferenceLinksAndDefinitions([DocumentLink[]]$Links) {
+    return $Links.Where({ $_.HasReference() -or $_.IsReference() })
+  }
+
+  hidden static [DocumentLink[]] FilterForUndefinedReferenceLinks([DocumentLink[]]$Links) {
+    return [DocumentLink]::FilterForReferenceLinks($Links).Where({
+        $ReferenceID = $_.IsSelfReferential() ? $_.Text : $_.ReferenceID
+        $ReferenceID -notin [DocumentLink]::FilterForReferenceDefinitions($Links).ReferenceID
+      }
+    )
+  }
+
+  hidden static [DocumentLink[]] FilterForUnusedReferenceLinkDefinitions([DocumentLink[]]$Links) {
+    return [DocumentLink]::FilterForReferenceDefinitions($Links).Where({
+        ($_.ReferenceID -notin [DocumentLink]::FilterForReferenceLinks($Links).ReferenceID) -and
+        ($_.ReferenceID -notin [DocumentLink]::FilterForSelfReferentialLinks($Links).Text)
+      }
+    )
+  }
+
+  hidden static [DocumentLink[]] FilterForValidReferenceLinksAndDefinitions([DocumentLink[]]$Links) {
+    $InvalidReferences = (
+      [DocumentLink]::FilterForUndefinedReferenceLinks($Links) +
+      [DocumentLink]::FilterForUnusedReferenceLinkDefinitions($Links)
+    )
+    return [DocumentLink]::FilterForReferenceLinksAndDefinitions($Links).Where({ $_ -notin $InvalidReferences })
+  }
+}

--- a/Source/Modules/Documentarian/Source/Public/Classes/LinkKindTransformAttribute.psm1
+++ b/Source/Modules/Documentarian/Source/Public/Classes/LinkKindTransformAttribute.psm1
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using namespace System.Management.Automation
+using module ../Enums/LinkKind.psm1
+
+class LinkKindTransformAttribute : ArgumentTransformationAttribute {
+  [object] Transform([EngineIntrinsics]$engineIntrinsics, [System.Object]$inputData) {
+    $ValidEnums = [LinkKind].GetEnumNames()
+    $outputData = switch ($inputData) {
+      { $_ -is [LinkKind] } { $_ }
+
+      { $_ -is [string] } {
+        if ($_ -in $ValidEnums) {
+          $_
+        } elseif ($Matching = $ValidEnums -like $_) {
+          $Matching
+        } else {
+          $Message = @(
+            "Specified kind '$_' couldn't resolve to any LinkKind enums;"
+            'values must be a specific LinkKind or a wildcard expression'
+            "(containing '*', '?', or '[]') matching one or more LinkKind."
+            "Valid LinkKind enums are: $ValidEnums"
+          ) -join ' '
+          throw [ArgumentTransformationMetadataException]::New(
+            $Message
+          )
+        }
+      }
+      default {
+        $Message = @(
+          "Could not convert input ($_) of type '$($_.GetType().FullName)' to a LinkKind."
+          "Specify a valid LinkKind or a wildcard expression (containing '*', '?', or '[]')"
+          "matching one or more LinkKind enums. Valid LinkKind enums are: $ValidEnums"
+        ) -join ' '
+        throw [ArgumentTransformationMetadataException]::New(
+          $Message
+        )
+      }
+    }
+
+    return $outputData
+  }
+}

--- a/Source/Modules/Documentarian/Source/Public/Classes/ParsedDocument.psm1
+++ b/Source/Modules/Documentarian/Source/Public/Classes/ParsedDocument.psm1
@@ -1,14 +1,67 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+using module ./DocumentLink.psm1
+
 class ParsedDocument {
   [System.IO.FileInfo]$FileInfo
   [string]$RawContent
   [Markdig.Syntax.MarkdownDocument]$ParsedMarkdown
   [System.Collections.Specialized.OrderedDictionary]$FrontMatter
   [string]$Body
+  [DocumentLink[]]$Links
+
+  hidden [bool]$HasParsedLinks
 
   ParsedDocument() {}
+
+  hidden ParseLinksFromBody() {
+    $this.Links = [DocumentLink]::Parse($this.Body)
+    | ForEach-Object -Process {
+      # Add the file info to each link
+      $_.Position.FileInfo = $FileInfo
+      # Emit the link for the list
+      $_
+    }
+
+    $this.HasParsedLinks = $true
+  }
+
+  [DocumentLink[]] ParsedLinks([bool]$Force) {
+    if (!$this.HasParsedLinks -or $Force) {
+      $this.ParseLinksFromBody()
+    }
+
+    return $this.Links
+  }
+
+  [DocumentLink[]] InlineLinks() {
+    return [DocumentLink]::FilterForInlineLinks($this.Links)
+  }
+
+  [DocumentLink[]] ReferenceLinks() {
+    return [DocumentLink]::FilterForReferenceLinks($this.Links)
+  }
+
+  [DocumentLink[]] ReferenceDefinitions() {
+    return [DocumentLink]::FilterForReferenceDefinitions($this.Links)
+  }
+
+  [DocumentLink[]] ReferenceLinksAndDefinitions() {
+    return [DocumentLink]::FilterForReferenceLinksAndDefinitions($this.Links)
+  }
+
+  [DocumentLink[]] UndefinedReferenceLinks() {
+    return [DocumentLink]::FilterForUndefinedReferenceLinks($this.Links)
+  }
+
+  [DocumentLink[]] UnusedReferenceLinkDefinitions() {
+    return [DocumentLink]::FilterForUnusedReferenceLinkDefinitions($this.Links)
+  }
+
+  [DocumentLink[]] ValidReferenceLinksAndDefinitions() {
+    return [DocumentLink]::FilterForValidReferenceLinksAndDefinitions($this.Links)
+  }
 
   [string] ToDecoratedString() {
     return $this.Body

--- a/Source/Modules/Documentarian/Source/Public/Classes/ParsingPatterns.psm1
+++ b/Source/Modules/Documentarian/Source/Public/Classes/ParsingPatterns.psm1
@@ -1,0 +1,162 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+  <#Category#>'PSUseConsistentIndentation',
+  <#CheckId#>$null,
+  Justification = 'Easier readability for regex strings from arrays'
+)]
+class ParsingPatterns {
+  # Anything following this is the start of a valid inline/block for Markdown. The value can be
+  # used to find code fence openings, link reference definitions, etc.
+  static [string] $LineLead = @(
+    '^'                              # Anchors to start of line
+    '(?<Lead>'                       # Lead captures whitespace + block notation
+      '(?<LeadingWhiteSpace>\s*)'    # May start with any amount of leading whitespace
+      '(?<BlockNotation>'            # May be in a list or blockquote
+        "(?'BlockQuoteBefore'>\s+)*" # Blockquote, like '> ```', '>  > ```', etc.
+        '(?<ListNotation>'           # A list can follow a block quote
+          '(?<OrderedList>\d+\. )'   # Ordered list, like '1. ```' or '15. ```'
+          '|'                        #
+          '(?<UnorderedList>[-+*] )' # Unordered list, like '- ```', '* ```', or '+ ```'
+        ')?'                         #
+        "(?'BlockQuoteAfter'>\s+)?"  # Blockquotes can come after a list, too, but only once
+      ')?'                           # Doesn't need to have a block
+    ')'                              # Close lead capture group
+  ) -join ''
+
+  # Returns a pattern for finding everything inside square brackets using balance groups with an optional name.
+  # To use the same pattern more than once in a regex, the balance groups need unique names.
+  static [string] InSquareBrackets([string]$BalanceGroupName) {
+    $OpenGroup = "Open$BalanceGroupName"
+    $CloseGroup = [string]::IsNullOrWhiteSpace($BalanceGroupName) ? 'Close' : $BalanceGroupName
+    return @(
+      '(?:'                                                       # Open bracket group finder
+        '(?:'                                                     #
+          "(?<$OpenGroup>\[)"                        # Open balance group starts with [
+          '(?:`` .* ``|`[^`]*`|[^\[\]])*'                         # Anything inside inline code or not-[]
+        ')+'                                                    # At least one
+        '(?:'                                                     #
+          "(?<$CloseGroup-$OpenGroup>\])" # Push to stack on ]
+          '(?:`` .* ``|`[^`]*`|[^\[\]])*?'                         # Anything inside inline code or not-[]
+        ')+?'                                                    # At least one
+      ')+?'                                                      # Must match at least once
+      "(?($OpenGroup)(?!))"                          # If open exists (ie not-matching # of ]), fail
+    ) -join ''
+  }
+
+  # This will return the whole thing, need to trim [] from start and end for
+  # text. Need to reparse text for nested.
+  static [string] InSquareBrackets() {
+    return [ParsingPatterns]::InSquareBrackets('')
+  }
+
+  # Double backticks are difficult - we can't reuse capture groups inside a
+  # pattern to know that we're closing the right one. We'll just assume it's
+  # always `` ... `` for now. Theoretically you could nest them but that
+  # seems like a tiny edge case for most documents.
+  static [string] $MultitickInlineCode = @(
+    '(?<open>`{2,}) '    # Multi-backtick inline code opens with 2+ backticks and a space
+    '(?<text>(?:'        # Capture everything until the code closes, don't capture sub-group
+      '.(?!\k<open>))*.' # Anything not followed by the code closer, then that character too
+    ')'                  # Close the text capture group
+    '\k<open>'           # The code is closed only by the same number of backticks it opened with.
+  ) -join ''
+
+  # Finds the opening for a codefence with leading components and the actual fence. This is useful
+  # so we can effectively find the matching closing fence.
+  static [string] $OpenCodeFence = @(
+    [ParsingPatterns]::LineLead # Retrieves any leading whitespace/block syntax
+    '(?<Fence>`{3,}|~{3,})'     # Fences can be backticks or tildes, don't care about after.
+  ) -join ''
+
+  # Finds any comment block, including unclosed comment blocks so we know if a multi-line comment
+  # is starting. Used for ignoring otherwise valid syntax.
+  static [string] $HtmlCommentBlock = @(
+    "(?'OpenComment'<!--)"
+    "(?'InComments'(?:.(?!-->))*.)"
+    "(?'CloseComment'-->)?"
+  ) -join ''
+
+  # Only used for discovering the closure point of a multi-line HTML comment so we can ignore
+  # otherwise valid syntax that comes before the closure.
+  static [string] $ClosingMultiLineHtmlComment = @(
+    '^'
+    "(?'InComments'(?:.(?!-->))*.)"
+    "(?'CloseComment'-->)"
+    "(?'AfterComment'.*)"
+  ) -join ''
+
+  # Finds a match within a set of single backticks, the most common syntax for inline code.
+  static [string] InsideSingleBacktick([string]$InnerPattern) {
+    return @(
+      '`[^`]*'      # Opening backtick followed by zero-or-more not-backticks
+      $InnerPattern # Inner regex between close and open
+      '[^`]*`'      # zero-or-more not-backticks followed by closing backtick
+    ) -join ''
+  }
+
+  # Helper method for discovering whether a string of text is inside any inline code blocks
+  # for a given line of Markdown.
+  static [bool] NotInsideInlineCode([string]$Line, [string]$FullMatch) {
+    $EscapedMatch = [regex]::Escape($FullMatch)
+    $SingleBacktickPattern = [ParsingPatterns]::InsideSingleBacktick($EscapedMatch)
+
+    # First find all multitick codeblocks, grab their raw value
+    $MultitickCodeBlocks = [regex]::Matches($Line, [ParsingPatterns]::MultitickInlineCode)?.Value
+
+    # If the text is inside a multitick codeblock, it's in a codeblock.
+    # If it isn't inside a multitick codeblock, it might still be in a single-tick codeblock.
+    if (($MultitickCodeBlocks.Count -ge 1) -and ($MultitickCodeBlocks -match $EscapedMatch)) {
+      return $false
+    } elseif ($Line -match $SingleBacktickPattern) {
+      return $false
+    }
+
+    # The text wasn't inside any codeblocks
+    return $true
+  }
+
+  # Needed to make it easier to read the combined pattern; also reused for reference definitions.
+  static [string] $LinkDefinition = @(
+    '(?<Destination>\S+)' # The URL component, capture any non-whitespace
+    '(?:\s+(?:'           # The title component, leads with non-captured whitespace
+      "'(?<Title>[^']*)'" # May be wrapped in non-captured single-quotes
+      '|'                 # or
+      '"(?<Title>[^"]*)"' # May be wrapped in non-captured double-quotes
+    '))?'                 # Make sure title is optional.
+  ) -join ''
+
+  # Finds a Markdown link in a given line. This pattern is likely hugely non-performant on a
+  # non-split document. It's also not codeblock-aware. Only use it on a single line known not
+  # to be inside a Markdown codeblock.
+  static [string] $Link = @(
+    '(?<IsImage>!)?'                        # If the link has a ! prefix, it's an image
+    "(?<Text>$(                           #
+      # [ParsingPatterns]::InSquareBracketsP # Need to retrieve the text inside the brackets.
+      [ParsingPatterns]::InSquareBrackets('Text')             # Need to retrieve the text inside the brackets.
+    ))"                                   #
+    '(?!:)'                                 # Ignore if followed by colon - that's a ref def
+    '(?:'                                   # Text can be followed by an inline def/ref/null
+      "\($(                                 #
+        [ParsingPatterns]::LinkDefinition   # Inline Definition, optional destination/title
+      )\)"                                  #
+      '|'                                   #
+      "(?<ReferenceID>$(                  #
+        # [ParsingPatterns]::InSquareBracketsP
+        [ParsingPatterns]::InSquareBrackets('ReferenceID')             # Need to retrieve the text inside the brackets.
+      ))"                                 #
+    ')?'                                    # The definition and reference syntax is optional
+  ) -join ''
+
+  # Finds a link reference definition, which can be inside a block.
+  static [string] $LinkReferenceDefinition = @(
+    [ParsingPatterns]::LineLead           # Retrieves any leading whitespace/block syntax
+    "(?<ReferenceID>$(                  #
+      # [ParsingPatterns]::InSquareBrackets # Need to retrieve the text inside the brackets as ID
+      [ParsingPatterns]::InSquareBrackets()
+    ))"                                 #
+    ':\s+'                                # Must be followed by a colon and at least one space
+    [ParsingPatterns]::LinkDefinition     # Inline Definition, optional destination/title
+  ) -join ''
+}

--- a/Source/Modules/Documentarian/Source/Public/Classes/Position.psm1
+++ b/Source/Modules/Documentarian/Source/Public/Classes/Position.psm1
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+class Position {
+  [System.IO.FileInfo]$FileInfo
+  [int]$LineNumber
+  [int]$StartColumn
+
+  [string] ToString() {
+    return "$($this.FileInfo):$($this.LineNumber):$($this.StartColumn)"
+  }
+}

--- a/Source/Modules/Documentarian/Source/Public/Enums/.LoadOrder.jsonc
+++ b/Source/Modules/Documentarian/Source/Public/Enums/.LoadOrder.jsonc
@@ -12,5 +12,10 @@
         "Name": "MarkdownExtension",
         "IgnoreForBuild": false,
         "IgnoreForTest": false
+    },
+    {
+        "Name": "LinkKind",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
     }
 ]

--- a/Source/Modules/Documentarian/Source/Public/Enums/LinkKind.psm1
+++ b/Source/Modules/Documentarian/Source/Public/Enums/LinkKind.psm1
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum LinkKind {
+  TextInline          # [<Text>](<Definition>)
+  TextSelfReference   # [<Text>]
+  TextUsingReference  # [<Text>][<Reference>]
+  ImageInline         # ![<AltText>](<Definition>)
+  ImageSelfReference  # ![<AltText>]
+  ImageUsingReference # ![<AltText>][<Reference>]
+  ReferenceDefinition # [<Name>]: <Definition>
+}

--- a/Source/Modules/Documentarian/Source/Public/Functions/General/Get-Document.ps1
+++ b/Source/Modules/Documentarian/Source/Public/Functions/General/Get-Document.ps1
@@ -38,7 +38,8 @@ function Get-Document {
       }
     }
 
-    foreach ($File in $Files) {
+    $Files | ForEach-Object -Process {
+      $File = $_
       if ($File.Extension -ne '.md') {
         continue
       }

--- a/Source/Modules/Documentarian/Source/Public/Functions/General/Get-DocumentLink.ps1
+++ b/Source/Modules/Documentarian/Source/Public/Functions/General/Get-DocumentLink.ps1
@@ -1,0 +1,142 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../../Classes/ParsedDocument.psm1
+using module ../../Classes/DocumentLink.psm1
+using module ../../Classes/LinkKindTransformAttribute.psm1
+using module ../../Enums/LinkKind.psm1
+
+#region    RequiredFunctions
+
+$SourceFolder = $PSScriptRoot
+while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
+  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+}
+$RequiredFunctions = @(
+  Resolve-Path -Path "$SourceFolder/Public/Functions/General/Get-Document.ps1"
+)
+foreach ($RequiredFunction in $RequiredFunctions) {
+  . $RequiredFunction
+}
+
+#endregion RequiredFunctions
+
+function Get-DocumentLink {
+  [CmdletBinding(DefaultParameterSetName = 'FilterByKind')]
+  [OutputType([DocumentLink])]
+  param(
+    [Parameter(
+      ParameterSetName = 'FilterByKind',
+      ValueFromPipeline,
+      ValueFromPipelineByPropertyName
+    )]
+    [Parameter(
+      ParameterSetName = 'FilterByOnly',
+      ValueFromPipeline,
+      ValueFromPipelineByPropertyName
+    )]
+    [Alias('FullName')]
+    [string[]]$Path,
+    [Parameter(ParameterSetName = 'FilterByKind', ValueFromPipeline)]
+    [Parameter(ParameterSetName = 'FilterByOnly', ValueFromPipeline)]
+    [ParsedDocument[]]$Document,
+    [Parameter(ParameterSetName = 'FilterByKind')]
+    [LinkKindTransformAttribute()]
+    [LinkKind[]]$IncludeKind,
+    [Parameter(ParameterSetName = 'FilterByKind')]
+    [LinkKindTransformAttribute()]
+    [LinkKind[]]$ExcludeKind,
+    [Parameter(ParameterSetName = 'FilterByOnly')]
+    [ValidateSet(
+      'Inline',
+      'References',
+      'UndefinedReferences',
+      'UnusedReferences',
+      'ValidReferences'
+    )]
+    [string]$Only,
+    [regex]$MatchMarkdown,
+    [regex]$MatchText,
+    [regex]$MatchDestination,
+    [regex]$MatchReferenceID,
+    [regex]$NotMatchMarkdown,
+    [regex]$NotMatchText,
+    [regex]$NotMatchDestination,
+    [regex]$NotMatchReferenceID
+  )
+
+  process {
+    if ($Path) {
+      $Document = Get-Document -Path $Path
+    }
+
+    $Document | ForEach-Object {
+      $ParsedDocument = $_
+      $Links = $ParsedDocument.Links
+
+      switch ($Only) {
+        'Inline' {
+          $Links = $ParsedDocument.InlineLinks()
+        }
+
+        'References' {
+          $Links = $ParsedDocument.ReferenceLinksAndDefinitions()
+        }
+
+        'UndefinedReferences' {
+          $Links = $ParsedDocument.UndefinedReferenceLinks()
+        }
+
+        'UnusedReferences' {
+          $Links = $ParsedDocument.UnusedReferenceLinkDefinitions()
+        }
+
+        'ValidReferences' {
+          $Links = $ParsedDocument.ValidReferenceLinksAndDefinitions()
+        }
+      }
+
+      if ($IncludeKind.Count) {
+        $Links = $Links.Where({ $_.Kind -in $IncludeKind })
+      }
+
+      if ($ExcludeKind.Count) {
+        $Links = $Links.Where({ $_.Kind -notin $ExcludeKind })
+      }
+
+      if ($MatchMarkdown) {
+        $Links = $Links.Where({ $_.Markdown -match $MatchMarkdown })
+      }
+
+      if ($MatchText) {
+        $Links = $Links.Where({ $_.Text -match $MatchText })
+      }
+
+      if ($MatchDestination) {
+        $Links = $Links.Where({ $_.Destination -match $MatchDestination })
+      }
+
+      if ($MatchReferenceID) {
+        $Links = $Links.Where({ $_.ReferenceID -match $MatchReferenceID })
+      }
+
+      if ($NotMatchMarkdown) {
+        $Links = $Links.Where({ $_.Markdown -notmatch $NotMatchMarkdown })
+      }
+
+      if ($NotMatchText) {
+        $Links = $Links.Where({ $_.Text -notmatch $NotMatchText })
+      }
+
+      if ($NotMatchDestination) {
+        $Links = $Links.Where({ $_.Destination -notmatch $NotMatchDestination })
+      }
+
+      if ($NotMatchReferenceID) {
+        $Links = $Links.Where({ $_.ReferenceID -notmatch $NotMatchReferenceID })
+      }
+
+      $Links
+    }
+  }
+}

--- a/Source/Modules/Documentarian/Test/Fixtures/Links/Basic.md
+++ b/Source/Modules/Documentarian/Test/Fixtures/Links/Basic.md
@@ -1,0 +1,46 @@
+# Header
+
+This is a [markdown](/concepts/markdown.md) file.
+
+You can add links like:
+
+> ```md
+> [<text>](url 'title')
+> ```
+
+[another](one), with [a third](too 'even a caption').
+
+Links can be [self-referencing]. Sometimes, [self-reference] and [reference][a]
+links don't have defined references.
+
+- [nested lists](are-fine.md)
+- No link here.
+
+  1. But there is here! [haha](hehee.md)
+
+- No worries.
+- > Even blockquotes can have [links][01].
+  >
+  > ````md
+  > But not in [fences](nope.md)
+  > ````
+  >
+  > ![Images work too!](image.png)
+  >
+  > Can you use a [link reference][02] with the def in a block?
+  >
+  > [02]: maybe.md
+
+- The real danger is `[inline](links.md "in code")`.
+- We'll work on `` those, [too](invalid.md) `` of course.
+
+Also <!-- [links](inside.md "comments") --> are a problem [sometimes](anyway.md).
+
+![Between](comments.md)
+
+Especially since <!-- Comments can [begin][03]
+and end anywhere --> [but then](its.md "okay").
+
+[01]: links-from-reference.md
+[self-referencing]: self.md
+[never-used]: not-for.md "any link"

--- a/Source/Modules/Documentarian/Test/Fixtures/Links/SelfReferential.md
+++ b/Source/Modules/Documentarian/Test/Fixtures/Links/SelfReferential.md
@@ -1,0 +1,7 @@
+# Self-referential links
+
+This is [some thing], you know?
+
+[some thing]
+
+[some thing]: some-thing


### PR DESCRIPTION
# PR Summary

Prior to this change, there was no built-in way to retrieve the list of links in a Markdown document with **Documentarian**.

This change:

- Adds the `Get-DocumentLink` function, which enables a user to retrieve the links from a Markdown file (by path or **ParsedDocument** object) and filter them by their **Kind** and matching options.
- Adds the **ParsingPatterns** static class, which includes regex patterns and methods for reuse across other classes and functions.
- Adds the **LinkKind** enum, which defines the kind of links you can find in a Markdown document:

  - `TextInline` - the basic Markdown link, like `[foo](bar "baz")`
  - `TextSelfReference` - A Markdown link that defines its reference ID as its link text, like `[foo]`
  - `TextUsingReference` - A Markdown link that defines an explicit reference ID, like `[foo][01]`
  - `ImageInline` - the basic Markdown image link, like `![foo](bar "baz")`
  - `ImageSelfReference` - A Markdown image link that defines its reference ID as its alt text, like `![foo]`
  - `ImageUsingReference` - A Markdown image link that defines an explicit reference ID, like `![foo][01]`
  - `ReferenceDefinition` - A Markdown link reference definition that allows shorter/reusable links with a separate definition, like `[01]: bar "baz"`
- Adds the **LinkKindTransformAttribute** class for converting a string that's a wildcard expression into the matching **LinkKind** enums for easier use in function parameters.
- Adds the **Position** class, which defines where an item is inside a document. This is used for understanding/finding links in a document but may be reused for other purposes.
- Adds the **DocumentLink** class, which defines a link by these properties:

  - **Kind** - the type of link (see **LinkKind** above), useful for converting links or verifying link types used
  - **Text** - the text that becomes the inner HTML for `Text*` links or the alt text for `Image*` links
  - **Destination** - the URI used as the `href` attribute for `Text*` links and the `src` attribute for `Image*` links
  - **Title** - the text that is used as the `title` attribute
  - **Position** - where the link is located in the document
  - **Markdown** - the raw text defining the link in the document

  It also defines the static **Parse** method with an overload for a string and a file for parsing links from Markdown and returning the list of discovered links.
- Updates **ParsedDocument** to have a **Links** property for holding the document's links and adds the `Links()` method for retrieving the links from the document, optionally re-parsing the body if desired.
- Updates `New-ParsedDocument` to parse the document's links, caching them on the instance of the object, before returning the new object.
- Resolves #16 

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
