### PR TITLE
(MAINT) Add discussion templates for proposals

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/code-proposals.yaml
+++ b/.github/DISCUSSION_TEMPLATE/code-proposals.yaml
@@ -1,0 +1,34 @@
+title: '[Code Proposal] '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest a new feature or change to an existing one. For the Documentarian modules, we
+        convert code proposal discussions into issues once we understand them well enough to decide
+        whether they should be implemented.
+
+        Sometimes this requires further discussion and investigation, sometimes a proposal may be
+        accepted as it was submitted.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: >-
+        Write a clear and concise description of the proposed feature or change. Why is it needed?
+        What gap will it fill? Who is the intended user? What scenarios will it address?
+      placeholder: |
+        Try formulating the need for this feature or change as a user story.
+
+        > As a user of <module>, I want <feature or change> so that <synopsis of value>.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    validations:
+      required: true
+    attributes:
+      label: Details
+      description: >-
+        Please provide extended details that will add context and help the team understand the
+        proposed feature or change. You can use this space to show a possible UX, describe ideas in
+        detail, and prompt for additional thoughts or investigation.

--- a/.github/DISCUSSION_TEMPLATE/docs-proposals.yaml
+++ b/.github/DISCUSSION_TEMPLATE/docs-proposals.yaml
@@ -1,0 +1,68 @@
+title: '[Docs Proposal] '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest a new document or major rewrite of an existing one. For the Documentarian modules,
+        we convert docs proposal discussions into issues once we understand them well enough to
+        decide whether they should be implemented.
+
+        Sometimes this requires further discussion and investigation, sometimes a proposal may be
+        accepted as it was submitted.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: >-
+        Write a clear and concise description of the proposed document or change. Why is it needed?
+        What gap will it fill? Who is the intended audience? What scenarios will it address?
+      placeholder: |
+        Try formulating the need for this documentation as a user story.
+
+        > As a user of <module>, I want a document about <topic> so that <synopsis of value>.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    validations:
+      required: true
+    attributes:
+      label: Details
+      description: >-
+        Please provide extended details that will add context and help the team understand the
+        proposed documentation. You can use this space to explain how existing docs don't meet your
+        needs, describe ideas in detail, and prompt for additional thoughts or investigation.
+  - type: dropdown
+    id: type
+    validations:
+      required: true
+    attributes:
+      label: Proposed Content Type
+      description: >-
+        Choose the type or types of documentation required.
+      multiple: true
+      options:
+        - Cmdlet Reference
+        - About Topic
+        - Concept
+        - Other / Unknown
+  - type: input
+    id: title
+    validations:
+      required: false
+    attributes:
+      label: Proposed Title
+  - type: textarea
+    id: related_documents
+    validations:
+      required: false
+    attributes:
+      label: Related Articles
+      description: >-
+        Provide a list of links to the documentation page(s) that are related to this request. Use
+        the markdown list syntax for each item. If the entire article is relevant, just link to the
+        permalink for its source or the live page. If only a section of the article is relevant, use
+        the permalink to the lines for the most relevant section of the source or the anchor link to
+        the nearest header for the relevant content instead of the page itself.
+      placeholder: |
+        - https://github.com/microsoft/Documentarian/blob/7acedbe93f3f5a40d03217fd6c1f0da1d062a2ae/Content/docs/authoring/_index.md

--- a/.github/ISSUE_TEMPLATE/code-idea.yml
+++ b/.github/ISSUE_TEMPLATE/code-idea.yml
@@ -15,7 +15,7 @@ body:
       options:
         - label: >-
             **Accepted Idea:** Proposals in this project are created based on ideas that have been
-            marked as `Accepted` in their [Discussion](https://github.com/michaeltlombardi/DocumentarianModules/discussions/categories/ideas).
+            marked as `Accepted` in their [Discussion](https://github.com/microsoft/Documentarian/discussions/categories/code-proposals).
             Before you file an issue for a feature or change, create a discussion. If you file an
             issue without a discussion, the team may convert it into one.
           required: true

--- a/.github/ISSUE_TEMPLATE/docs-idea.yml
+++ b/.github/ISSUE_TEMPLATE/docs-idea.yml
@@ -16,7 +16,7 @@ body:
       options:
         - label: >-
             **Accepted Idea:** Proposals in this project are created based on ideas that have been
-            marked as `Accepted` in their [Discussion](https://github.com/michaeltlombardi/DocumentarianModules/discussions/categories/ideas).
+            marked as `Accepted` in their [Discussion](https://github.com/microsoft/Documentarian/discussions/categories/docs-proposals).
             Before you file an issue for new document or a rewrite, create a discussion. If you file
             an issue without a discussion, the team may convert it into one.
           required: true
@@ -101,4 +101,4 @@ body:
         the permalink to the lines for the most relevant section of the source or the anchor link to
         the nearest header for the relevant content instead of the page itself.
       placeholder: |
-        - https://github.com/michaeltlombardi/DocumentarianModules/blob/211f4d77e387c52659428be15f208a3e137ff1cc/Documentarian.Vale/Docs/Reference/Test-Vale.md
+        - https://github.com/microsoft/Documentarian/blob/7acedbe93f3f5a40d03217fd6c1f0da1d062a2ae/Content/docs/authoring/_index.md


### PR DESCRIPTION
# PR Summary

This change uses the new [discussion templates][01] feature to add structured forms for filing proposal discussions.

[01]: https://github.blog/2023-01-09-github-discussions-just-got-better-with-category-forms/

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
