### PR TITLE
(MAINT) Fix titling for modules

### DIFF
--- a/Source/Modules/Documentarian.MicrosoftDocs.PSDocs/Documentation/_index.md
+++ b/Source/Modules/Documentarian.MicrosoftDocs.PSDocs/Documentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentarian.MicrosoftDocs.PSDocs
-linkTitle: 
+linkTitle: MicrosoftDocs.PSDocs
 summary: The development experience toolkit for authoring and maintaining modern PowerShell modules
 description: >-
   The development experience toolkit for modern PowerShell modules.

--- a/Source/Modules/Documentarian.MicrosoftDocs/Documentation/_index.md
+++ b/Source/Modules/Documentarian.MicrosoftDocs/Documentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentarian.MicrosoftDocs
-linkTitle:
+linkTitle: MicrosoftDocs
 summary: >-
   A PowerShell module for maintainers and contributors to Microsoft documentation.
 description: |

--- a/Source/Modules/Documentarian.ModuleAuthor/Documentation/_index.md
+++ b/Source/Modules/Documentarian.ModuleAuthor/Documentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentarian.ModuleAuthor
-linkTitle:
+linkTitle: ModuleAuthor
 summary: >-
   A module for writing and maintaining PowerShell module documentation as a supplement to
   **PlatyPS**.

--- a/Source/Modules/Documentarian.Vale/Documentation/_index.md
+++ b/Source/Modules/Documentarian.Vale/Documentation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentarian.Vale
-linkTitle: 
+linkTitle: Vale
 summary: The development experience toolkit for authoring and maintaining modern PowerShell modules
 description: >-
   The development experience toolkit for modern PowerShell modules.

--- a/Source/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-Vale.md
+++ b/Source/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-Vale.md
@@ -56,7 +56,7 @@ This cmdlet doesn't support any pipeline input.
 
 ## OUTPUTS
 
-### System.Management.Automation.ApplicationInfo
+### {{% xref "System.Management.Automation.ApplicationInfo" %}}
 
 This cmdlet returns an **ApplicationInfo** object for the Vale binary, if found.
 


### PR DESCRIPTION


# PR Summary

This change updates the front matter for the module documentation to set the `title` to the module name and the `linkTitle` to the short name for the module with the `Documentarian.` prefix removed.

This avoids horizontal scrolling for the navigation while maintaining the correct title for the modules.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
