### PR TITLE
(MAINT) Add exportable tasks to DevX

### DIFF
--- a/Source/Modules/Documentarian.DevX/.DevX.jsonc
+++ b/Source/Modules/Documentarian.DevX/.DevX.jsonc
@@ -37,5 +37,6 @@
   // "SourceManifestPath": "./Manifest.psd1"
   // "SourcePrivateFolderPath": "",
   // "SourcePublicFolderPath": ""
-  "SourceTemplateFolderPath": "./Source/Templates"
+  "SourceTemplateFolderPath": "./Source/Templates",
+  "TaskAliasPrefix": "DevX"
 }

--- a/Source/Modules/Documentarian.DevX/.build.ps1
+++ b/Source/Modules/Documentarian.DevX/.build.ps1
@@ -26,24 +26,24 @@ $FunctionFinderParams = @{
   Include = '*.ps1'
   Exclude = '*.Tests.ps1'
 }
+$TemplateFolder = Join-Path -Path 'Source' -ChildPath 'Templates'
+$TasksFolder = Join-Path -Path 'Source' -ChildPath 'Public' -AdditionalChildPath 'Tasks'
+
 $Functions = Get-ChildItem @FunctionFinderParams
 | Where-Object -FilterScript {
-  $_.FullName -notmatch [regex]::Escape((Join-Path -Path 'Source' -ChildPath 'Templates'))
+  $_.FullName -notmatch [regex]::Escape($TemplateFolder) -and
+  $_.FullName -notmatch [regex]::Escape($TasksFolder)
 }
 
 foreach ($Function in $Functions) {
-  Write-Verbose $Function.FullName
+  Write-Verbose "Loading function: $($Function.FullName)"
   . $Function.FullName
 }
 
-# Compose the Documentarian.DevX.psm1 file from source.
-task ComposeModule {
-  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
+foreach ($TaskFile in (Get-ChildItem -Path $TasksFolder -Filter '*.ps1')) {
+  Write-Verbose "Loading task: $($TaskFile.BaseName)"
+  . $TaskFile
 }
 
-task CheckDependencies {
-  Get-Module -ListAvailable
-}
-
-# Default task composes the module and writes the manifest
+# Synopsis: Default task composes the module and writes the manifest
 task . ComposeModule

--- a/Source/Modules/Documentarian.DevX/Source/Private/Functions/Resolve-NameSpace.ps1
+++ b/Source/Modules/Documentarian.DevX/Source/Private/Functions/Resolve-NameSpace.ps1
@@ -96,6 +96,7 @@ function Resolve-NameSpace {
         Enum { "Enums.$Scope" }
         Function { "Functions.$Scope" }
         Format { "Formats.$Scope" }
+        Task { "Tasks.$Scope" }
         Type { "Types.$Scope" }
       }
     }

--- a/Source/Modules/Documentarian.DevX/Source/Public/Classes/.LoadOrder.jsonc
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Classes/.LoadOrder.jsonc
@@ -39,6 +39,11 @@
         "IgnoreForTest": false
     },
     {
+        "Name": "TaskDefinition",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
         "Name": "ModuleComposer",
         "IgnoreForBuild": false,
         "IgnoreForTest": false

--- a/Source/Modules/Documentarian.DevX/Source/Public/Classes/TaskDefinition.psm1
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Classes/TaskDefinition.psm1
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../../Private/Enums/UncommonLineEndingAction.psm1
+using module ./SourceFile.psm1
+using module ./SourceFolder.psm1
+
+class TaskDefinition {
+  [string]$Name
+  [SourceFile[]]$SourceFiles
+
+  [string] GetTaskName([string]$Prefix) {
+    return "$Prefix.$($this.Name)"
+  }
+
+  [string] GetTaskPath([string]$Prefix) {
+    return @(
+      '$PSScriptRoot'
+      'Tasks'
+      "$($this.GetTaskName($Prefix)).ps1"
+    ) -join '/'
+  }
+
+  [string] ComposeContent() {
+    if ($this.SourceFiles.Count -eq 0) {
+      return ''
+    }
+
+    $Output = New-Object -TypeName System.Text.StringBuilder
+
+    $this.SourceFiles.MungedContent | ForEach-Object -Process {
+      $Output.AppendLine($_).AppendLine()
+    }
+
+    return $Output.ToString()
+  }
+}

--- a/Source/Modules/Documentarian.DevX/Source/Public/Enums/SourceCategory.psm1
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Enums/SourceCategory.psm1
@@ -6,5 +6,6 @@ enum SourceCategory {
   Enum
   Function
   Format
+  Task
   Type
 }

--- a/Source/Modules/Documentarian.DevX/Source/Public/Functions/General/Get-SourceFolder.ps1
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Functions/General/Get-SourceFolder.ps1
@@ -24,7 +24,7 @@ function Get-SourceFolder {
   param(
     [Parameter(Mandatory, ParameterSetName = 'ByOption')]
     [Parameter(ParameterSetName = 'WithSpecificFolders')]
-    [ValidateSet('Classes', 'Enums', 'Formats', 'Functions', 'Types')]
+    [ValidateSet('Classes', 'Enums', 'Formats', 'Functions', 'Tasks', 'Types')]
     [string[]]$Category,
 
     [Parameter(Mandatory, ParameterSetName = 'ByOption')]
@@ -34,7 +34,7 @@ function Get-SourceFolder {
 
     [Parameter(ParameterSetName = 'ByPreset')]
     [Parameter(ParameterSetName = 'WithSpecificFolders')]
-    [ValidateSet('Ordered', 'Functions', 'PS1Xmls', 'All')]
+    [ValidateSet('Ordered', 'Functions', 'PS1Xmls', 'Tasks', 'All')]
     [string]$Preset = 'All',
 
     [Parameter(ParameterSetName = 'ByPreset')]
@@ -54,7 +54,7 @@ function Get-SourceFolder {
   )
 
   process {
-    $Category ??= @('Classes', 'Enums', 'Formats', 'Functions', 'Types')
+    $Category ??= @('Classes', 'Enums', 'Formats', 'Functions', 'Tasks', 'Types')
     $CategoryPattern = "\b$($Category -join '|')\b"
     if ($SourceFolder) {
       $PublicFolder = Join-Path -Path $SourceFolder -ChildPath 'Public'
@@ -94,6 +94,12 @@ function Get-SourceFolder {
         )
       }
 
+      'Tasks' {
+        @(
+          Join-Path -Path $PublicFolder -ChildPath Tasks
+        )
+      }
+
       'All' {
         @(
           Join-Path -Path $PrivateFolder -ChildPath Enums
@@ -103,6 +109,7 @@ function Get-SourceFolder {
           Join-Path -Path $PrivateFolder -ChildPath Functions
           Join-Path -Path $PublicFolder -ChildPath Functions
           Join-Path -Path $PublicFolder -ChildPath Formats
+          Join-Path -Path $PublicFolder -ChildPath Tasks
           Join-Path -Path $PublicFolder -ChildPath Types
         )
       }

--- a/Source/Modules/Documentarian.DevX/Source/Public/Tasks/.TaskList.jsonc
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Tasks/.TaskList.jsonc
@@ -1,0 +1,14 @@
+[
+  { // Becomes 'DevX.Task.ComposeModule'
+    "Name": "Task.ComposeModule",
+    "Include": [
+      "ComposeModule"
+    ]
+  },
+  {
+    "Name": "Tasks",
+    "Include": [
+      "ComposeModule"
+    ]
+  }
+]

--- a/Source/Modules/Documentarian.DevX/Source/Public/Tasks/ComposeModule.ps1
+++ b/Source/Modules/Documentarian.DevX/Source/Public/Tasks/ComposeModule.ps1
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Synopsis: Compose the module from source files
+task ComposeModule {
+  Build-ComposedModule -ProjectRootFolderPath $BuildRoot
+}

--- a/Source/Modules/Documentarian.MarkdownLint/.build.ps1
+++ b/Source/Modules/Documentarian.MarkdownLint/.build.ps1
@@ -15,14 +15,8 @@ param(
   $Configuration = 'Test'
 )
 
-# Compose the module files from source.
-task ComposeModule {
-  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
-}
-
-task CheckDependencies {
-  Get-Module -ListAvailable
-}
+# Import the bundled tasks from Documentarian.DevX
+. DevX.Tasks
 
 # Default task composes the module and writes the manifest
 task . ComposeModule

--- a/Source/Modules/Documentarian.MicrosoftDocs/.build.ps1
+++ b/Source/Modules/Documentarian.MicrosoftDocs/.build.ps1
@@ -15,14 +15,8 @@ param(
   $Configuration = 'Test'
 )
 
-# Compose the module files from source.
-task ComposeModule {
-  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
-}
-
-task CheckDependencies {
-  Get-Module -ListAvailable
-}
+# Import the bundled tasks from Documentarian.DevX
+. DevX.Tasks
 
 # Default task composes the module and writes the manifest
 task . ComposeModule

--- a/Source/Modules/Documentarian.ModuleAuthor/.build.ps1
+++ b/Source/Modules/Documentarian.ModuleAuthor/.build.ps1
@@ -15,14 +15,8 @@ param(
   $Configuration = 'Test'
 )
 
-# Compose the module files from source.
-task ComposeModule {
-  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
-}
-
-task CheckDependencies {
-  Get-Module -ListAvailable
-}
+# Import the bundled tasks from Documentarian.DevX
+. DevX.Tasks
 
 # Default task composes the module and writes the manifest
 task . ComposeModule

--- a/Source/Modules/Documentarian.Vale/.build.ps1
+++ b/Source/Modules/Documentarian.Vale/.build.ps1
@@ -15,14 +15,8 @@ param(
   $Configuration = 'Test'
 )
 
-# Compose the module files from source.
-task ComposeModule {
-  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
-}
-
-task CheckDependencies {
-  Get-Module -ListAvailable
-}
+# Import the bundled tasks from Documentarian.DevX
+. DevX.Tasks
 
 # Default task composes the module and writes the manifest
 task . ComposeModule

--- a/Source/Modules/Documentarian/.build.ps1
+++ b/Source/Modules/Documentarian/.build.ps1
@@ -15,14 +15,8 @@ param(
   $Configuration = 'Test'
 )
 
-# Compose the Documentarian.DevX.psm1 file from source.
-task ComposeModule {
-  Build-ComposedModule -ProjectRootFolderPath $PSScriptRoot
-}
-
-task CheckDependencies {
-  Get-Module -ListAvailable
-}
+# Import the bundled tasks from Documentarian.DevX
+. DevX.Tasks
 
 # Default task composes the module and writes the manifest
 task . ComposeModule


### PR DESCRIPTION
Prior to this change, the build definitions for each module re-implemented lines of code. This change adds another type of exportable functionality to modules created using the DevX pattern by supporting Invoke-Build tasks.

With this change, modules can define tasks in the `Tasks` subfolder of their public source folder and have them exported as aliases that can be dot-sourced in other build definitions as long as the module is imported.

This behavior is controlled by the `.TaskList.jsonc` file, which allows you to define one or more tasks by a friendly name to enable loading only particular tasks or task groups.

This initial implementation is naive and suited to our needs, but could be expanded on to better support broader use cases.

In addition to making it easier to reuse the DevX tasks in our own modules without copy-pasting task updates, this will allow us to publish helpful tasks in our modules for common workflows like updating or testing documents.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
