### PR TITLE
Exclude tab links from conversion

### DIFF
--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Convert-MDLinks.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Convert-MDLinks.ps1
@@ -30,7 +30,10 @@ function Convert-MDLinks {
 
         function GetMDLinks {
             foreach ($mdlink in $mdlinks.Matches) {
-                if (-not $mdlink.Value.Trim().StartsWith('[!INCLUDE')) {
+                # Skip INCLUDE and tab links
+                if (-not $mdlink.Value.Trim().StartsWith('[!INCLUDE') -and
+                    -not $mdlink.Value.Trim().Contains('#tab/')
+                ) {
                     $linkitem = [pscustomobject]([ordered]@{
                             mdlink = ''
                             target = ''


### PR DESCRIPTION
Exclude tab links from conversion. Tabbed content overloads the markdown link syntax. This change excludes tabbed content from the link conversion.

