### PR TITLE
(MAINT) Replace use of ordered hashtable & accelerator

### DIFF
--- a/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeConfigurationEffective.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeConfigurationEffective.psm1
@@ -56,7 +56,7 @@ class ValeConfigurationEffective {
 
     ValeConfigurationEffective() {}
 
-    ValeConfigurationEffective([System.Management.Automation.OrderedHashtable]$Info) {
+    ValeConfigurationEffective([hashtable]$Info) {
         $Info.BlockIgnores.GetEnumerator() | ForEach-Object -Process {
             $this.BlockIgnores += [ValeConfigurationIgnore]@{
                 GlobPattern    = $_.Key

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeRule.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeRule.psm1
@@ -4,7 +4,7 @@ class ValeRule {
     [string]$Style
     [string]$Name
     [string]$Path
-    [ordered]$Properties
+    [hashtable]$Properties
 
     ValeRule([string]$Style, [string]$Name, [string]$Path) {
         $this.Style = $Style

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Invoke-Vale.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Invoke-Vale.ps1
@@ -18,7 +18,7 @@ foreach ($RequiredFunction in $RequiredFunctions) {
 
 function Invoke-Vale {
   [CmdletBinding()]
-  [OutputType([System.Management.Automation.OrderedHashtable])]
+  [OutputType([hashtable])]
   [OutputType([String])]
   param(
     [parameter(Mandatory)]


### PR DESCRIPTION
# PR Summary

The `[ordered]` type accelerator and **OrderedHashtable** types are not fully compatible with older versions of PowerShell. This change replaces their usage in the **Documentarian.Vale** module.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
