### PR TITLE
(MAINT) Add `ParameterAttributeKind` to load order

### DIFF
--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Enums/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Enums/.LoadOrder.jsonc
@@ -10,5 +10,10 @@
         "Name": "ProviderFlags",
         "IgnoreForBuild": false,
         "IgnoreForTest": false
+    },
+    {
+        "Name": "ParameterAttributeKind",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
     }
 ]


### PR DESCRIPTION
# PR Summary

This change ensures the **ParameterAttributeKind** enum is included in the `.LoadOrder.jsonc` file and thus included in the composed module.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
