### PR TITLE
(MAINT) Handle invalid configs for Vale

### DIFF
--- a/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Invoke-Vale.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Invoke-Vale.ps1
@@ -71,6 +71,28 @@ function Invoke-Vale {
               )
 
               $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+            } elseif ($Result.Text -match 'is a syntax-specific option') {
+              $Message = @(
+                "Invalid value at '$($Result.Path):$($Result.Line):$($Result.Span)'."
+                $Result.Text
+              ) -join ' '
+              $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                ([System.Runtime.Serialization.SerializationException]$Message),
+                'Vale.InvalidConfigurationValue',
+                [System.Management.Automation.ErrorCategory]::InvalidData,
+                ($ArgumentList -join ' ')
+              )
+
+              $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+            } else {
+              $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+              ([System.Exception]$_),
+                'Vale.UnhandledError',
+                [System.Management.Automation.ErrorCategory]::FromStdErr,
+              ($ArgumentList -join ' ')
+              )
+
+              $PSCmdlet.WriteError($ErrorRecord)
             }
           }
           # E100 is the code for unexpected errors in Vale


### PR DESCRIPTION
# PR Summary

Prior to this change the `Invoke-Vale` command failed silently when the Vale configuration file was invalid, swallowing E201 errors that were not explicitly handled.

This change adds specific handling for invalid configuration keys and a fallthrough handler for not-yet-known E201 errors.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
