### PR TITLE
Add support for PR and Issue numbered links

### DIFF
--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Convert-MDLinks.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Convert-MDLinks.ps1
@@ -118,7 +118,7 @@ function Convert-MDLinks {
             } else {
                 $bang = ''
             }
-            if ($linkdata[$x].target -match 'https://github.com/\w+/\w+/(pull|issues)/(?<linkid>\d+)') {
+            if ($linkdata[$x].target -match 'https://github.com/\w+/\w+/(pull|issues)/(?<linkid>\d+)$') {
                 $linkid = $matches.linkid
                 $newlinks += '[{0}]: {1}' -f $linkid, $linkdata[$x].target
                 $newlink = '[{0}][{1}]' -f $linkdata[$x].label, $linkid

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/ConvertTo-Contraction.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/ConvertTo-Contraction.ps1
@@ -13,7 +13,7 @@ function ConvertTo-Contraction {
     )
 
     ### This function converts common word pairs to contractions. It doesn't handle all possible
-    ### cases and it is not aware of code blocks.
+    ### cases and it's not aware of code blocks.
 
     $contractions = @{
         lower = @{
@@ -68,7 +68,7 @@ function ConvertTo-Contraction {
             foreach ($key in $contractions.upper.keys) {
                 $mdtext = $mdtext -creplace $key, $contractions.upper[$key]
             }
-            Set-Content -Path $_ -Value $mdtext -Encoding utf8 -Force
+            Set-Content -Path $_ -Value $mdtext -NoNewline -Encoding utf8 -Force
         }
     }
 


### PR DESCRIPTION
# PR Summary

Before this PR `Convert-MDLinks`:
- Would not find links inside of parentheses
- Would renumber links to GitHub PRs and issues where the link ref was the GitHub item number

Also, `ConvertTo-Contraction` would add an extra newline to the end of the file.

This PR addresses these problems

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
