### PR TITLE
(MAINT) Add `New-ValeConfiguration`

### DIFF
--- a/.github/workflows/build.pwsh.yaml
+++ b/.github/workflows/build.pwsh.yaml
@@ -42,11 +42,11 @@ jobs:
       - name: Install PowerShell modules
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module InvokeBuild, PlatyPS, PowerShell-Yaml -ErrorAction Stop
+          Install-Module InvokeBuild, PlatyPS, PowerShell-Yaml, PsIni -ErrorAction Stop
       - name: InvokeBuild
         run: |
           $PSVersionTable
-          Get-Module -ListAvailable InvokeBuild, PlatyPS, PowerShell-Yaml |
+          Get-Module -ListAvailable InvokeBuild, PlatyPS, PowerShell-Yaml, PsIni |
             Format-Table -Property Name, Version, Path
           Push-Location ./Projects/Modules
           Invoke-Build -Module ${{ matrix.module }}

--- a/.github/workflows/test.pwsh.yaml
+++ b/.github/workflows/test.pwsh.yaml
@@ -30,11 +30,11 @@ jobs:
       - name: Install PowerShell modules
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module InvokeBuild, PlatyPS, PowerShell-Yaml -ErrorAction Stop
+          Install-Module InvokeBuild, PlatyPS, PowerShell-Yaml, PsIni -ErrorAction Stop
       - name: Test ${{ matrix.module }}
         run: |
           $PSVersionTable
-          Get-Module -ListAvailable InvokeBuild, PlatyPS, PowerShell-Yaml |
+          Get-Module -ListAvailable InvokeBuild, PlatyPS, PowerShell-Yaml, PsIni |
             Format-Table -Property Name, Version, Path
           Push-Location ./Projects/Modules
           Invoke-Build

--- a/Projects/Modules/Documentarian.Vale/.DevX.jsonc
+++ b/Projects/Modules/Documentarian.Vale/.DevX.jsonc
@@ -10,6 +10,9 @@
     "Copyright": "(c) Microsoft. All rights reserved.",
     "Description": "Collection of tools for installing and using the Vale prose linter.",
     "PowerShellVersion": "7.2",
+    "RequiredModules": [
+      "PsIni"
+    ],
     "Tags": [
       "Markdown",
       "Documentation",

--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Install-WorkspaceVale.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Install-WorkspaceVale.md
@@ -2,7 +2,7 @@
 external help file: Documentarian.Vale-help.xml
 Locale: en-US
 Module Name: Documentarian.Vale
-online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/Install-WorkspaceVale
+online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/install-workspacevale
 schema: 2.0.0
 title: Install-WorkspaceVale
 ---

--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/New-ValeConfiguration.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/New-ValeConfiguration.md
@@ -1,0 +1,254 @@
+﻿---
+external help file: Documentarian.Vale-help.xml
+Locale: en-US
+Module Name: Documentarian.Vale
+online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/new-valeconfiguration
+schema: 2.0.0
+title: New-ValeConfiguration
+---
+
+# New-ValeConfiguration
+
+## SYNOPSIS
+Create a minimal configuration file for Vale.
+
+## SYNTAX
+
+```
+New-ValeConfiguration
+ [[-FilePath] <String>]
+ [[-StylesPath] <String>]
+ [[-MinimumAlertLevel] <ValeAlertLevel>]
+ [[-StylePackage] <String[]>]
+ [-Force]
+ [-PassThru]
+ [-NoSpelling]
+ [-NoSync]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `New-ValeConfiguration` cmdlet is a helper function for creating a basic Vale configuration
+file. By default, it creates the `.vale.ini` file in the working directory with the same settings
+as Vale's own [configuration generator](https://vale.sh/generator/) and then immediately syncs the
+newly created configuration.
+
+You can use the **FilePath** parameter to create the configuration file in a different location or
+with a different name. You can use the **StylesPath** to change where style packages are placed when
+you use the `Sync-Vale` command.
+
+The **StylePackage** parameter can automatically complete values for known Vale style packages. It
+can also handle arbitrary packages, like those published to a URL or included in a local zip folder.
+
+You can use the **NoSpelling** switch to prevent the new configuration from including Vale's
+built-in spell checking. Use the **NoSync** switch if you don't want to sync the styles immediately.
+
+## EXAMPLES
+
+### Example 1: Create a basic Vale configuration
+
+In this example, the `New-ValeConfiguration` cmdlet creates the `.vale.ini` file in the working
+directory. It immediately syncs the `Microsoft` package, downloading it into the `.vscode/styles`
+folder.
+
+```powershell
+New-ValeConfiguration -StylesPath '.vscode/styles' -StylePackage Microsoft
+Get-Content -Path ./.vale.ini
+Get-ValeStyle
+```
+
+```output
+Packages=Microsoft
+StylesPath=.vscode/styles
+MinAlertLevel=suggestion
+[*]
+BasedOnStyles=Vale, Microsoft
+
+Name      Path                                  Rules
+----      ----                                  -----
+Microsoft C:\code\temp\.vscode\styles\Microsoft {Accessibility, Acronyms, Adverbs, AMPM…}
+```
+
+The output from `Get-ValeStyle` shows that the `Microsoft` style has been synced and can be used.
+
+## PARAMETERS
+
+### -FilePath
+
+Specify the path to the configuration file to create. By default, the cmdlet creates the
+`.vale.ini` file in the current working directory.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Specify whether the cmdlet should replace an existing configuration file if one exists at the same
+path. By default, the cmdlet throws an exception when the configuration file already exists.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinimumAlertLevel
+
+Specify the minimum alert level for the configuration file. This affects whether Vale ignores any
+rules. The default value is `Suggestion`, which ensures all violations are reported.
+
+```yaml
+Type: ValeAlertLevel
+Parameter Sets: (All)
+Aliases:
+Accepted values: Suggestion, Warning, Error
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSpelling
+
+Use this parameter to prevent the configuration from including Vale's built-in spell checking. By
+default, new configurations use Vale to check spelling.
+
+If you use this parameter, you must also use the **StylePackage** parameter to specify one or more
+style packages to include in the configuration. Vale won't work without at least one style when
+spelling is disabled.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSync
+
+Use this parameter to avoid immediately syncing the specified style packages. By default, this
+cmdlet sync the newly created configuration so it can be used immediately. Most Vale commands fail
+when a configuration hasn't been synced.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+
+Use this parameter to specify that this cmdlet should return the created configuration file as a
+**System.IO.FileInfo** object. By default, this cmdlet returns no output.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StylePackage
+
+Use this parameter to specify any number of Vale style packages to use when linting prose. By
+default, no packages are included. This cmdlet includes an argument completer for well-known
+Vale packages, but you can use any valid style package.
+
+To use a local style package, specify the value as the path to the `.zip` archive containing it. The
+archive must have the same name as the style. The path can be relative to the new configuration file
+or absolute.
+
+To use a remote style package, specify the value as the url to the `.zip` archive containing it. The
+archive must have the same name as the style.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StylesPath
+
+Specify the folder for Vale to store the style packages. The default value is the `styles` folder
+in the same directory as the configuration file. If this value is a relative path, the path is
+relative to the configuration file, not the current working directory.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`,
+`-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`,
+`-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+This cmdlet doesn't support any pipeline input.
+
+## OUTPUTS
+
+### None
+
+By default, this cmdlet returns no output.
+
+### System.IO.FileSystemInfo
+
+If the **PassThru** parameter is specified, the cmdlet returns the **FileInfo** for the created
+configuration file.
+
+## NOTES
+
+## RELATED LINKS

--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Sync-Vale.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Sync-Vale.md
@@ -2,7 +2,7 @@
 external help file: Documentarian.Vale-help.xml
 Locale: en-US
 Module Name: Documentarian.Vale
-online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/
+online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/sync-vale
 schema: 2.0.0
 title: Sync-Vale
 ---
@@ -15,7 +15,7 @@ Installs or updates the Vale style packages for a configuration.
 ## SYNTAX
 
 ```
-Sync-Vale [<CommonParameters>]
+Sync-Vale [-Path <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,6 +23,12 @@ Sync-Vale [<CommonParameters>]
 The `Sync-Vale` cmdlet installs or updates the Vale style packages for a configuration. If the
 style packages don't exist in the configured style path, the cmdlet installs them there. If the
 style packages exist, the cmdlet updates them if needed.
+
+By default, this cmdlet synchronizes the `.vale.ini` configuration file in the current working
+directory.
+
+You can use the **Path** parameter to install or update the Vale style packages for a configuration
+in a different folder or with a different name.
 
 ## EXAMPLES
 
@@ -35,6 +41,23 @@ Sync-Vale
 ```
 
 ## PARAMETERS
+
+### -Path
+
+Specify the path to a Vale configuration file. If this parameter isn't specified, Vale looks for
+the `.vale.ini` configuration file from the current working directory.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### CommonParameters
 
@@ -51,9 +74,9 @@ This cmdlet doesn't support any pipeline input.
 
 ## OUTPUTS
 
-### System.Object
+### None
 
-This cmdlet passes through the progress information from Vale itself.
+This cmdlet doesn't return any output.
 
 ## NOTES
 

--- a/Projects/Modules/Documentarian.Vale/Source/Init.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Init.ps1
@@ -13,3 +13,26 @@
     obviate the need to remember to call the `using` statement on the
     module and ensures the public classes and enums are available.
 #>
+
+$PackageNameCompleter = {
+  param(
+    $commandName,
+    $parameterName,
+    $wordToComplete,
+    $commandAst,
+    $fakeBoundParameters
+  )
+
+  [ValeKnownStylePackage].GetEnumNames() | Where-Object {
+    $_ -like "$wordToComplete*"
+  } | ForEach-Object {
+    $_
+  }
+}
+
+$PackageNameCompleterParams = @{
+  CommandName   = 'New-ValeConfiguration'
+  ParameterName = 'StylePackage'
+  ScriptBlock   = $PackageNameCompleter
+}
+Register-ArgumentCompleter @PackageNameCompleterParams

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Classes/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Classes/.LoadOrder.jsonc
@@ -7,6 +7,16 @@
     //     "IgnoreForTest": false
     // }
     {
+        "Name": "ValeStylePackageTransformAttribute",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "ValeStyleNameTransformAttribute",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
         "Name": "ValeApplicationInfo",
         "IgnoreForBuild": false,
         "IgnoreForTest": false

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeStyleNameTransformAttribute.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeStyleNameTransformAttribute.psm1
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using namespace System.Management.Automation
+using module ../Enums/ValeKnownStylePackage.psm1
+
+class ValeStyleNameTransformAttribute : ArgumentTransformationAttribute {
+    [object] Transform([EngineIntrinsics]$engineIntrinsics, [System.Object]$inputData) {
+        $ValidEnums = [ValeKnownStylePackage].GetEnumNames()
+        $outputData = switch ($inputData) {
+            { $_ -in $ValidEnums } {
+                switch ([ValeKnownStylePackage]$_) {
+                    Alex {
+                        'alex'
+                        continue
+                    }
+                    JobLint {
+                        'Joblint'
+                        continue
+                    }
+                    PowerShellDocs {
+                        'PowerShell-Docs'
+                        continue
+                    }
+                    ProseLint {
+                        'proselint'
+                        continue
+                    }
+                    WriteGood {
+                        'write-good'
+                        continue
+                    }
+                    default { $_.ToString() }
+                }
+                continue
+            }
+
+            { $_ -is [string] } { $_ }
+
+            default {
+                $Message = @(
+                    "Could not convert input ($_) of type '$($_.GetType().FullName)' to a string."
+                ) -join ' '
+                throw [ArgumentTransformationMetadataException]::New(
+                    $Message
+                )
+            }
+        }
+
+        return $outputData
+    }
+}

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeStylePackageTransformAttribute.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeStylePackageTransformAttribute.psm1
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using namespace System.Management.Automation
+using module ../Enums/ValeKnownStylePackage.psm1
+
+class ValeStylePackageTransformAttribute : ArgumentTransformationAttribute {
+    [object] Transform([EngineIntrinsics]$engineIntrinsics, [System.Object]$inputData) {
+        $ValidEnums = [ValeKnownStylePackage].GetEnumNames()
+        $outputData = switch ($inputData) {
+            { $_ -in $ValidEnums } {
+                switch ([ValeKnownStylePackage]$_) {
+                    Alex {
+                        'alex'
+                        continue
+                    }
+                    JobLint {
+                        'Joblint'
+                        continue
+                    }
+                    PowerShellDocs {
+                        'https://microsoft.github.io/Documentarian/packages/vale/PowerShell-Docs.zip'
+                        continue
+                    }
+                    ProseLint {
+                        'proselint'
+                        continue
+                    }
+                    WriteGood {
+                        'write-good'
+                        continue
+                    }
+                    default { $_.ToString() }
+                }
+                continue
+            }
+
+            { $_ -is [string] } { $_ }
+
+            default {
+                $Message = @(
+                    "Could not convert input ($_) of type '$($_.GetType().FullName)' to a string."
+                ) -join ' '
+                throw [ArgumentTransformationMetadataException]::New(
+                    $Message
+                )
+            }
+        }
+
+        return $outputData
+    }
+}

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Enums/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Enums/.LoadOrder.jsonc
@@ -10,5 +10,10 @@
         "Name": "ValeAlertLevel",
         "IgnoreForBuild": false,
         "IgnoreForTest": false
+    },
+    {
+        "Name": "ValeKnownStylePackage",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
     }
 ]

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Enums/ValeKnownStylePackage.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Enums/ValeKnownStylePackage.psm1
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum ValeKnownStylePackage {
+    Vale
+    Alex
+    Google
+    Hugo
+    JobLint
+    Microsoft
+    PowerShellDocs
+    ProseLint
+    Readability
+    RedHat
+    WriteGood
+}

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Functions/New-ValeConfiguration.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Functions/New-ValeConfiguration.ps1
@@ -1,0 +1,137 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Enums/ValeAlertLevel.psm1
+using module ../Classes/ValeStylePackageTransformAttribute.psm1
+using module ../Classes/ValeStyleNameTransformAttribute.psm1
+
+function New-ValeConfiguration {
+    [cmdletbinding()]
+    [OutputType([System.IO.FileSystemInfo])]
+    param(
+        [Parameter(Position = 0)]
+        [string]$FilePath = './.vale.ini',
+
+        [string]$StylesPath,
+
+        [ValeAlertLevel]$MinimumAlertLevel,
+
+        [ValeStylePackageTransform()]
+        [string[]] $StylePackage,
+
+        [switch]$Force,
+
+        [switch]$PassThru,
+
+        [switch]$NoSpelling,
+
+        [switch]$NoSync
+    )
+
+    begin {
+        # The configuration needs to be ordered and the root section must be defined first.
+        # The implementation for PsIni skips writing a section when adding sectionless keys,
+        # so if they come after the '*' section, the configuration file is malformed.
+        $Configuration = New-Object -TypeName System.Collections.Specialized.OrderedDictionary
+        $Configuration.Add('_', @{
+                StylesPath    = 'styles'
+                MinAlertLevel = 'suggestion'
+                Packages      = @()
+            }
+        )
+        $Configuration.Add('*', @{
+                BasedOnStyles = @()
+            }
+        )
+        $ConfigExists = Test-Path -Path $FilePath
+    }
+
+    process {
+        if ($ConfigExists -and -not $Force) {
+            $ResolvedPath = Resolve-Path $FilePath
+            $Message = "Specified Vale configuration file already exists at '$ResolvedPath'."
+
+            $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                ([System.ArgumentException]$Message),
+                'Vale.ConfigurationFileAlreadyExists',
+                [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                $FilePath
+            )
+
+            $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+        }
+
+        if (![string]::IsNullOrEmpty($StylesPath)) {
+            $Configuration._.StylesPath = $StylesPath
+        }
+
+        if ($null -ne $MinimumAlertLevel) {
+            $Configuration._.MinAlertLevel = $MinimumAlertLevel.ToString().ToLowerInvariant()
+        }
+
+        if (!$NoSpelling) {
+            $Configuration['*'].BasedOnStyles += 'Vale'
+        } elseif ($StylePackage.Count -eq 0) {
+            $Message = @(
+                'Must specify at least one style for the configuration when specifying NoSpelling.'
+                'Run the command again with at least one package specified for StylePackage'
+                'or without NoSpelling.'
+            ) -join ' '
+
+            $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                ([System.ArgumentException]$Message),
+                'Vale.NoStylePackagesSpecified',
+                [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                $PSBoundParameters
+            )
+
+            $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+        }
+
+        foreach ($Package in $StylePackage) {
+            # Skip duplicates
+            if ($Package -in $Configuration._.Packages) {
+                Write-Warning "Skipping duplicate package '$Package'"
+                continue
+            }
+
+            # For built-in packages, the package name and style name are the same.
+            $Style = $Package
+
+            # .zip packages are local or remote styles not built into Vale
+            if ($Package -match '.zip$') {
+                # Split for the last path segment, trim the '.zip' from the end.
+                # Definitionally, vale style packages must have the same name
+                # as their zip file.
+                $Style = (Split-Path $Package -Leaf) | ForEach-Object {
+                    $_.Substring(0, $_.Length - 4)
+                }
+            }
+
+            $Configuration._.Packages += $Package
+            $Configuration['*'].BasedOnStyles += $Style
+        }
+
+        # These need to convert to comma-separated strings for Vale to be happy;
+        # PsIni adds arrays as repeated entries by default.
+        $Configuration._.Packages = $Configuration._.Packages -join ', '
+        $Configuration['*'].BasedOnStyles = $Configuration['*'].BasedOnStyles -join ', '
+
+        try {
+            $OutputParameters = @{
+                InputObject = $Configuration
+                FilePath    = $FilePath
+                Force       = $Force
+                Passthru    = $PassThru
+                ErrorAction = 'Stop'
+            }
+            Out-IniFile @OutputParameters
+
+            if (!$NoSync) {
+                Sync-Vale -Path $FilePath
+            }
+        } catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+    }
+}

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Sync-Vale.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Sync-Vale.ps1
@@ -18,7 +18,10 @@ foreach ($RequiredFunction in $RequiredFunctions) {
 
 function Sync-Vale {
   [CmdletBinding()]
-  param()
+  param(
+    [Parameter(Position = 0)]
+    [string]$Path
+  )
 
   begin {
     $SyncParameters = @(
@@ -26,6 +29,10 @@ function Sync-Vale {
     )
   }
   process {
-    Invoke-Vale -ArgumentList $SyncParameters
+    if (![string]::IsNullOrEmpty($Path)) {
+      $SyncParameters += @('--config', $Path)
+    }
+
+    $null = Invoke-Vale -ArgumentList $SyncParameters
   }
 }


### PR DESCRIPTION


# PR Summary

This change adds the `New-ValeConfiguration` cmdlet and makes several changes in support of the new functionality.

Prior to this change, there was no way to get started using **Documentarian.Vale** without manually creating a config file. Now, users can leverage the module to install, configure, and use Vale on their documentation.

This change also:

- The new `ValeKnownStylePackage` enum, representing well-known Vale style packages and those we publish.
- Defines two new argument transformation attributes to enable converting from the `ValeKnownStylePackage` enum to their well-known name (with correct casing). For our own styles, this allows our users to specify an enum instead of having to know the URL for the package.
- Updates the init script to register an argument completer for `New-ValeConfiguration`, providing IntelliSense without limiting the valid values to _only_ well-known packages.
- Improves the error handling for `Invoke-Vale`
- Updates `Sync-Vale` to never return any output and to enable syncing configurations other than the current context.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
