### PR TITLE
(MAINT) Refactor `Get-ProseMetric` and rename `Get-Readability` to `Get-ProseReadability`

### DIFF
--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-ProseMetric.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-ProseMetric.md
@@ -15,7 +15,7 @@ Returns metrics about the prose in a document.
 ## SYNTAX
 
 ```
-Get-ProseMetric [[-Path] <String[]>] [<CommonParameters>]
+Get-ProseMetric [-Path] <String[]> [-Recurse] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,7 +49,7 @@ FileName           : C:\code\pwsh\Documentarian\README.md
 
 ### Example 2: Get the word count for files and folders
 
-```pwsh
+```powershell
 Get-ProseMetric .\README.md, .\CHANGELOG.md, .\Documentation\reference\cmdlets\ |
     Format-Table -Property Words, FileName
 ```
@@ -82,8 +82,24 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -Recurse
+
+Indicates that the cmdlet should get metrics for the Markdown files in child folders.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-ProseReadability.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-ProseReadability.md
@@ -1,13 +1,13 @@
 ---
 external help file: Documentarian.Vale-help.xml
 Module Name: Documentarian.Vale
-online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/get-readability
+online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/get-prosereadability
 schema: 2.0.0
 ms.date: 03/13/2023
-title: Get-Readability
+title: Get-ProseReadability
 ---
 
-# Get-Readability
+# Get-ProseReadability
 
 ## SYNOPSIS
 Returns the readability score of a markdown using Vale.
@@ -157,6 +157,22 @@ Accepted values: AutomatedReadability, ColemanLiau, FleschKincaid, FleschReading
 Required: False
 Position: 1
 Default value: AutomatedReadability
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Recurse
+
+Indicates that the cmdlet should get the readability scores for the Markdown files in child folders.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Formats/ValeMetricsInfo.Format.ps1xml
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Formats/ValeMetricsInfo.Format.ps1xml
@@ -30,12 +30,12 @@
                         <TableColumnItems>
                             <TableColumnItem>
                                 <ScriptBlock>
-                                    $Relative = Resolve-Path -Relative -Path $_.File
+                                    $Relative = Resolve-Path -Relative -Path $_.FileInfo.FullName
                                     if ($Relative.Length -lt 30) {
                                         return $Relative
                                     }
 
-                                    $_.Metrics.FileInfo.Name
+                                    $_.FileInfo.Name
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Formats/ValeReadability.Format.ps1xml
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Formats/ValeReadability.Format.ps1xml
@@ -10,75 +10,6 @@
             <ViewSelectedBy>
                 <TypeName>ValeReadability</TypeName>
             </ViewSelectedBy>
-            <TableControl>
-                <TableHeaders>
-                    <TableColumnHeader>
-                        <Label>Rule</Label>
-                        <Width>22</Width>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Score</Label>
-                        <Width>20</Width>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Threshold</Label>
-                        <Width>20</Width>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>File</Label>
-                        <Width>40</Width>
-                    </TableColumnHeader>
-                </TableHeaders>
-                <TableRowEntries>
-                    <TableRowEntry>
-                        <TableColumnItems>
-                            <TableColumnItem>
-                                <PropertyName>Rule</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <ScriptBlock>
-                                    if ($_.GradeLevel) {
-                                        $_.GradeLevel
-                                    } else {
-                                        [ValeReadability]::GetRoundedScore($_.Score)
-                                    }
-                                </ScriptBlock>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <ScriptBlock>
-                                    if ($_ -is [ValeMetricsAutomatedReadability]) {
-                                        [ValeReadability]::GetGradeLevel($_.Threshold)
-                                    } elseif ($_.GradeLevel) {
-                                        [ValeReadability]::GetGradeLevel($_.Threshold + 1)
-                                    } else {
-                                        $_.Threshold
-                                    }
-                                </ScriptBlock>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <ScriptBlock>
-                                    $Relative = Resolve-Path -Relative -Path $_.File
-                                    if ($Relative.Length -lt 30) {
-                                        return $Relative
-                                    }
-
-                                    if ($_.File.Length -gt 30) {
-                                        return $_.Metrics.FileInfo.Name
-                                    }
-
-                                    $_.File
-                                </ScriptBlock>
-                            </TableColumnItem>
-                        </TableColumnItems>
-                    </TableRowEntry>
-                </TableRowEntries>
-            </TableControl>
-        </View>
-        <View>
-            <Name>Default</Name>
-            <ViewSelectedBy>
-                <TypeName>ValeReadability#Grouped</TypeName>
-            </ViewSelectedBy>
             <GroupBy>
                 <ScriptBlock>
                     $_.Metrics.FileInfo.Directory
@@ -144,47 +75,6 @@
             <Name>Summary</Name>
             <ViewSelectedBy>
                 <TypeName>ValeReadability#ProblemMessage</TypeName>
-            </ViewSelectedBy>
-            <TableControl>
-                <TableHeaders>
-                    <TableColumnHeader>
-                        <Label>Message</Label>
-                        <Width>90</Width>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>File</Label>
-                        <Width>40</Width>
-                    </TableColumnHeader>
-                </TableHeaders>
-                <TableRowEntries>
-                    <TableRowEntry>
-                        <TableColumnItems>
-                            <TableColumnItem>
-                                <PropertyName>ProblemMessage</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <ScriptBlock>
-                                    $Relative = Resolve-Path -Relative -Path $_.File
-                                    if ($Relative.Length -lt 30) {
-                                        return $Relative
-                                    }
-
-                                    if ($_.File.Length -gt 30) {
-                                        return $_.Metrics.FileInfo.Name
-                                    }
-
-                                    $_.File
-                                </ScriptBlock>
-                            </TableColumnItem>
-                        </TableColumnItems>
-                    </TableRowEntry>
-                </TableRowEntries>
-            </TableControl>
-        </View>
-        <View>
-            <Name>Summary</Name>
-            <ViewSelectedBy>
-                <TypeName>ValeReadability#GroupedProblemMessage</TypeName>
             </ViewSelectedBy>
             <GroupBy>
                 <ScriptBlock>


### PR DESCRIPTION
# PR Summary

This change:

1. Refactors the `Get-ProseMetric` cmdlet for readability and UX.

   It slightly increases performance by ensuring that the processing is all streamed instead of collected-and-then-looped.

   It replaces the potentially surprising behavior (automatic recursion) with an explicit **Recurse** parameter and adds the correct attributes to the **Path** parameter.

   It also fixes a bug in the formatter so the File name actually displays.

2. Renames the `Get-Readability` cmdlet to `Get-ProseReadability` and refactors it.

   Instead of having grouped and ungrouped formats, it now always groups the results by folder. The new **Recurse** parameter reflects the same parameter in `Get-ProseMetric`.

   Finally, this change fixes a bug in the processing to ensure that non-Markdown files do not end the overall processing but instead move to the next object in the pipeline as intended.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
