### PR TITLE
(GH-91) Add `Install-Vale` command

### DIFF
--- a/Projects/Modules/Documentarian.Vale/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.Vale/CHANGELOG.md
@@ -19,10 +19,24 @@ description: |
 
 ## Unreleased
 
+### Changed
+
+- Renamed `Install-WorkspaceVale` to [`Install-Vale`] and added the **Scope** parameter, enabling
+  users to install Vale to their home directory as well as the workspace. This change ensures that
+  the other module commands are also able to use Vale when installed to your home directory, not
+  just the `PATH` or workspace.
+- Updated the logic for discovering Vale in the workspace to recursively search up the file tree
+  from the current working directory instead of only searching the current directory. This makes
+  the commands available from arbitrarily deep folders when using Vale installed to the workspace.
+
 ## [0.0.1] - 2023-03-27
 
 ### Added
 
 - Initial release.
 
+<!-- Link Reference Definitions -->
+[`Install-Vale`]: /modules/vale/reference/cmdlets/install-vale
+
+<!-- Release Links -->
 [0.0.1]: https://github.com/microsoft/Documentarian/releases/tag/Documentarian.Vale%2Fv0.0.1

--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-Vale.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Get-Vale.md
@@ -10,7 +10,7 @@ title: Get-Vale
 # Get-Vale
 
 ## SYNOPSIS
-Gets the command info for Vale installed in a workspace or on a machine.
+Gets the command info for Vale installed in a workspace, user's home folder, or on a machine.
 
 ## SYNTAX
 
@@ -21,11 +21,19 @@ Get-Vale [<CommonParameters>]
 ## DESCRIPTION
 
 The `Get-Vale` cmdlet returns a **System.Management.Automation.ApplicationInfo** object for the
-`vale` binary if it's available. It first checks the `PATH` environment variable and, if `vale`
-isn't available, checks the `.vale` folder in the current working directory.
+`vale` binary if it's available. It first checks for the `vale` application in the following order,
+returning the first discovered application:
 
-This cmdlet is a convenience helper for using Vale when installed to the workspace, as with the
-[Install-WorkspaceVale](/modules/vale/reference/cmdlets/install-workspacevale) cmdlet.
+1. It checks the `.vale` folder in the current working directory.
+1. It walks the directory tree up from the current working directory, checking the `.vale` folder
+   in each parent directory.
+1. It checks the `.vale` folder in the user's home directory.
+1. It checks the folders listed in the `PATH` environment variable.
+
+The cmdlet returns an error if it doesn't find the `vale` application.
+
+This cmdlet is a convenience helper for using Vale when installed to the workspace or user's home
+directory, as with the [Install-Vale](/modules/vale/reference/cmdlets/install-vale) cmdlet.
 
 ## EXAMPLES
 
@@ -68,4 +76,4 @@ reflecting Vale's version.
 
 ## RELATED LINKS
 
-[Install-WorkspaceVale](../install-workspacevale)
+[Install-Vale](../install-vale)

--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Install-Vale.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/cmdlets/Install-Vale.md
@@ -2,26 +2,32 @@
 external help file: Documentarian.Vale-help.xml
 Locale: en-US
 Module Name: Documentarian.Vale
-online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/install-workspacevale
+online version: https://microsoft.github.io/Documentarian/modules/vale/reference/cmdlets/install-vale
 schema: 2.0.0
-title: Install-WorkspaceVale
+title: Install-Vale
 ---
 
-# Install-WorkspaceVale
+# Install-Vale
 
 ## SYNOPSIS
-Installs Vale to the current working directory.
+Installs Vale to the current working directory or the user's home folder.
 
 ## SYNTAX
 
 ```
-Install-WorkspaceVale [[-Version] <String>] [-PassThru] [<CommonParameters>]
+Install-Vale
+ [[-Version] <String>]
+ [[-Scope] <ValeInstallScope>]
+ [-PassThru]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Install-WorkspaceVale` cmdlet is a helper for installing Vale into a project folder. When used,
-it installs Vale into the `.vale` folder of the current directory.
+The `Install-Vale` cmdlet is a helper for installing Vale into a project folder or the user's home
+directory. When used, it installs Vale into the `.vale` folder of the current directory by default.
+You can specify the **Scope** parameter as `User` to install Vale into the `.vale` folder in your
+home directory instead.
 
 This cmdlet is useful for installing Vale in CI or when you only need it for a specific project. It
 isn't a full alternative to using a package manager.
@@ -34,10 +40,16 @@ isn't a full alternative to using a package manager.
 Install-Vale
 ```
 
-### Example 1: Install a specific version of Vale
+### Example 2: Install a specific version of Vale
 
 ```powershell
 Install-Vale -Version 'v2.21.3'
+```
+
+### Example 3: Install Vale in your home folder
+
+```powershell
+Install-Vale -Scope User
 ```
 
 ## PARAMETERS
@@ -49,6 +61,25 @@ default, the cmdlet returns no output.
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Scope
+
+Specifies the scope to install Vale to. By default, Vale is installed in the `Workspace` scope.
+
+- `User` - Install Vale to the user's home directory in the `.vale` folder.
+- `Workspace` - Install vale to the current working directory in the `.vale` folder.
+
+```yaml
+Type: ValeInstallScope
 Parameter Sets: (All)
 Aliases:
 

--- a/Projects/Modules/Documentarian.Vale/Documentation/reference/enums/ValeInstallScope.md
+++ b/Projects/Modules/Documentarian.Vale/Documentation/reference/enums/ValeInstallScope.md
@@ -1,0 +1,28 @@
+---
+title: ValeInstallScope
+summary: Defines where `Install-Vale` should install the application
+description: >-
+  The **ValeInstallScope** enum defines where `Install-Vale` should install the application.
+---
+
+## Definition
+
+{{% src path="Public/Enums/ValeInstallScope.psm1" title="Source Code" /%}}
+
+## Fields
+
+### `User`
+
+Value
+: 0
+{ .pwsh-metadata }
+
+Indicates that Vale should be installed into the user's home directory in the `.vale` folder.
+
+### `Workspace`
+
+Value
+: 1
+{ .pwsh-metadata }
+
+Indicates that Vale should be installed into the current working directory in the `.vale` folder.

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Enums/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Enums/.LoadOrder.jsonc
@@ -12,6 +12,11 @@
         "IgnoreForTest": false
     },
     {
+        "Name": "ValeInstallScope",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
         "Name": "ValeKnownStylePackage",
         "IgnoreForBuild": false,
         "IgnoreForTest": false

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Enums/ValeInstallScope.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Enums/ValeInstallScope.psm1
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum ValeInstallScope {
+    User
+    Workspace
+}

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Get-Vale.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Get-Vale.ps1
@@ -9,16 +9,27 @@ function Get-Vale {
   param()
 
   process {
-    $ValeCommand = Get-Command -Name vale -ErrorAction Ignore
+    Write-Verbose 'Checking for vale in workspace...'
+    $Folder = Get-Location
+    do {
+      $ValeCommand = Get-Command "$Folder/.vale/vale" -ErrorAction Ignore
+      $Folder = Split-Path -Path $Folder -Parent
+    } until (($null -ne $ValeCommand) -or ([string]::IsNullOrEmpty($Folder)))
 
     if ($null -eq $ValeCommand) {
-      $ValeCommand = Get-Command "$(Get-Location)/.vale/vale" -ErrorAction Ignore
+      Write-Verbose 'Vale not found in workspace. Checking user scope...'
+      $ValeCommand = Get-Command '~/.vale/vale' -ErrorAction Ignore
+    }
+
+    if ($null -eq $ValeCommand) {
+      Write-Verbose 'Vale not found in user scope. Checking PATH...'
+      $ValeCommand = Get-Command -Name vale -ErrorAction Ignore
     }
 
     if ($null -eq $ValeCommand) {
       $Message = @(
-        "Can't find vale installed in path or workspace."
-        'You can use the Install-WorkspaceVale command or use your package manager to install it.'
+        "Can't find vale installed in workspace, home directory, or PATH."
+        'You can use the Install-Vale command or use your package manager to install it.'
       ) -join ' '
       throw  $Message
     }

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Install-Vale.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Install-Vale.ps1
@@ -1,11 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-function Install-WorkspaceVale {
+using module ../Enums/ValeInstallScope.psm1
+
+function Install-Vale {
   [CmdletBinding()]
   [OutputType([System.IO.FileInfo])]
   param(
     [string]$Version = 'latest',
+    [ValeInstallScope]$Scope = [ValeInstallScope]::Workspace,
     [switch]$PassThru
   )
 
@@ -38,7 +41,12 @@ function Install-WorkspaceVale {
     $PackageNamePattern = "vale_\d+\.\d+\.\d+_${OS}_${Architecture}${Extension}"
     $ChecksumNamePattern = '_checksums.txt$'
 
-    $InstallFolderPath = Join-Path -Path (Get-Location) -ChildPath '.vale'
+    $BaseInstallPath = if ($Scope -eq 'User') {
+      Get-Item -Path ~
+    } else {
+      Get-Location
+    }
+    $InstallFolderPath = Join-Path -Path $BaseInstallPath -ChildPath '.vale'
     $TempFolderPath = Join-Path -Path 'Temp:' -ChildPath (New-Guid).Guid
     $ArchiveFilePath = Join-Path -Path $TempFolderPath -ChildPath "vale${Extension}"
   }


### PR DESCRIPTION
Prior to this change, the **Documentarian.Vale** module included the `Install-WorkspaceVale` command, which enabled users to install Vale into their current working directory.

However, this required users to install Vale to every project, which also meant needing to modify the `.gitignore` file or continually manage an untracked folder in the project root.

This change:

- Renames `Install-WorkspaceVale` to `Install-Vale`.
- Adds support to `Get-Vale` for finding an installation in the user's home directory. If Vale isn't found in the `PATH`, the command now searches for `~/.vale/vale` before searching for `./.vale/vale`.
- Adds the `ValeInstallScope` enumeration, which is used by `Install-Vale` to determine where to install Vale. By default, the command installs Vale to the `Workspace` scope.
- Updates the documentation.
- Resolves #91 

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
