### PR TITLE
(MAINT) Add changelog link shortcodes

### DIFF
--- a/Projects/Hugo/docsy-pwsh/CHANGELOG.md
+++ b/Projects/Hugo/docsy-pwsh/CHANGELOG.md
@@ -15,8 +15,21 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Hugo/docs-pwsh
+  with_labels:
+    - docsy-pwsh
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
+Related Links
+: {{< changelog/link/prs >}}
+
+### Added
+
 - Initial Release
+
+<!-- Link Reference Definitions -->

--- a/Projects/Hugo/docsy-pwsh/layouts/shortcodes/changelog/link/prs.html
+++ b/Projects/Hugo/docsy-pwsh/layouts/shortcodes/changelog/link/prs.html
@@ -1,0 +1,51 @@
+{{- $Context    := .                                                     -}}
+{{- $Params     := $Context.Params                                       -}}
+{{- $SiteParams := site.Params                                           -}}
+{{- $PageParams := $Context.Page.Params.release_links                    -}}
+{{- $Before     := $Params.before                                        -}}
+{{- $After      := $Params.after                                         -}}
+{{- $withLabels := $Params.with_labels | default $PageParams.with_labels -}}
+{{- $skipLabels := $Params.skip_labels | default $PageParams.skip_labels -}}
+{{- $Repo       := $Params.repo
+                   | default $PageParams.repo_url
+                   | default $SiteParams.github_repo
+-}}
+
+{{- with $Repo -}}
+    {{- $url   := $Repo -}}
+    {{- $query := slice "is:pr" "is:merged" -}}
+    {{- with $withLabels -}}
+        {{- if not (reflect.IsSlice $withLabels) -}}
+            {{- $withLabels = split $withLabels "," -}}
+        {{- end -}}
+        {{- range $Label := $withLabels -}}
+            {{- $query = $query | append (printf "label:%s" (trim $Label " ")) -}}
+        {{- end -}}
+    {{- end -}}
+    {{- with $skipLabels -}}
+        {{- if not (reflect.IsSlice $skipLabels) -}}
+            {{- $skipLabels = split $skipLabels "," -}}
+        {{- end -}}
+        {{- range $Label := $skipLabels -}}
+            {{- $query = $query | append (printf "-label:%s" (trim $Label " ")) -}}
+        {{- end -}}
+    {{- end -}}
+    {{- with $Before -}}
+        {{- $query = $query | append (printf "-merged:>%s" $Before) -}}
+    {{- end -}}
+    {{- with $After -}}
+        {{- $query = $query | append (printf "-merged:<%s" $After) -}}
+    {{- end -}}
+    {{- $query = delimit $query " " -}}
+    {{- with $query -}}
+        {{- $query = querify "q" $query -}}
+        {{- $url   = printf "%s/pulls?%s" $url $query -}}
+    {{- else -}}
+        {{- $url = printf "%s/pulls" $url -}}
+    {{- end -}}
+
+    {{- $Link := printf "[Pull Requests](%s)" $url -}}
+    {{- $Link | $Context.Page.RenderString         -}}
+{{- else -}}
+    {{- errorf "Missing mandatory github repository url" -}}
+{{- end -}}

--- a/Projects/Hugo/docsy-pwsh/layouts/shortcodes/changelog/link/source.html
+++ b/Projects/Hugo/docsy-pwsh/layouts/shortcodes/changelog/link/source.html
@@ -1,0 +1,33 @@
+{{- $Context    := .                                                            -}}
+{{- $Params     := $Context.Params                                              -}}
+{{- $SiteParams := site.Params                                                  -}}
+{{- $PageParams := $Context.Page.Params.release_links                           -}}
+{{- $Tag        := $Params.tag                                           -}}
+{{- $SourcePath := $Params.source_path | default $PageParams.source_path -}}
+{{- $Repo       := $Params.repo
+                   | default $PageParams.repo_url
+                   | default $SiteParams.github_repo
+-}}
+
+{{- with $Tag -}}
+    {{- $url     := ""   -}}
+    {{/*  Get the version, selecting the last item in slash-inclusive tag if needed  */}}
+    {{- $version := $Tag -}}
+    {{- if in $Tag "/" -}}
+        {{- $version = index (last 1 (split $Tag "/")) 0 -}}
+    {{- end -}}
+    {{- $Text := printf "Source at `%s`" $version -}}
+    {{- with $Repo -}}
+        {{- $url = printf "%s/tree" $Repo }}
+    {{- else -}}
+      {{- errorf "Missing mandatory github repository url" -}}
+    {{- end -}}
+    {{- $url = printf "%s/%s" $url $Tag -}}
+    {{- with $SourcePath -}}
+        {{- $url = printf "%s/%s" $url $SourcePath -}}
+    {{- end -}}
+    {{- $Link := printf "[%s](%s)" $Text $url -}}
+    {{- $Link | $Context.Page.RenderString    -}}
+{{- else -}}
+    {{- errorf "Missing mandatory tag definition" -}}
+{{- end -}}

--- a/Projects/Modules/Documentarian.DevX/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.DevX/CHANGELOG.md
@@ -15,8 +15,21 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Modules/Documentarian.DevX
+  with_labels:
+    - Documentarian.DevX
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
+Related Links
+: {{< changelog/link/prs after="2022-10-14" >}}
+
+### Added
+
 - Scaffolded initial project.
+
+<!-- Link Reference Definitions -->

--- a/Projects/Modules/Documentarian.MarkdownLint/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.MarkdownLint/CHANGELOG.md
@@ -15,8 +15,21 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Modules/Documentarian.MarkdownLint
+  with_labels:
+    - Documentarian.MarkdownLint
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
+Related Links
+: {{< changelog/link/prs >}}
+
+### Added
+
 - Scaffolded initial project.
+
+<!-- Link Reference Definitions -->

--- a/Projects/Modules/Documentarian.MicrosoftDocs/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/CHANGELOG.md
@@ -15,14 +15,26 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Modules/Documentarian.MicrosoftDocs
+  with_labels:
+    - Documentarian.MicrosoftDocs
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
-## [0.0.1] - 2023-03-27
+Related Links
+: {{< changelog/link/prs after="2023-03-27" >}}
+
+## 0.0.1 - 2023-03-27
+
+Related Links
+: {{< changelog/link/source tag="Documentarian.MicrosoftDocs/v0.0.1" >}}
 
 ### Added
 
 - Initial release.
 
-[0.0.1]: https://github.com/microsoft/Documentarian/releases/tag/Documentarian.MicrosoftDocs%2Fv0.0.1
+<!-- Link Reference Definitions -->

--- a/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
@@ -15,14 +15,26 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Modules/Documentarian.ModuleAuthor
+  with_labels:
+    - Documentarian.ModuleAuthor
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
-## [0.0.1] - 2023-03-27
+Related Links
+: {{< changelog/link/prs after="2023-03-27" >}}
+
+## 0.0.1 - 2023-03-27
+
+Related Links
+: {{< changelog/link/source tag="Documentarian.ModuleAuthor/v0.0.1" >}}
 
 ### Added
 
 - Initial release.
 
-[0.0.1]: https://github.com/microsoft/Documentarian/releases/tag/Documentarian.ModuleAuthor%2Fv0.0.1
+<!-- Link Reference Definitions -->

--- a/Projects/Modules/Documentarian.Vale/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.Vale/CHANGELOG.md
@@ -15,11 +15,24 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Modules/Documentarian.Vale
+  with_labels:
+    - Documentarian.Vale
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
-## [0.1.0] - 2023-04-06
+Related Links
+: {{< changelog/link/prs after="2023-04-06" >}}
+
+## 0.1.0 - 2023-04-06
+
+Related Links
+: {{< changelog/link/source tag="Documentarian.Vale/v0.1.0" >}}
+: {{< changelog/link/prs after="2023-03-27" before="2023-04-06" >}}
 
 ### Changed
 
@@ -31,7 +44,10 @@ description: |
   from the current working directory instead of only searching the current directory. This makes
   the commands available from arbitrarily deep folders when using Vale installed to the workspace.
 
-## [0.0.1] - 2023-03-27
+## 0.0.1 - 2023-03-27
+
+Related Links
+: {{< changelog/link/source tag="Documentarian.Vale/v0.0.1" >}}
 
 ### Added
 
@@ -39,7 +55,3 @@ description: |
 
 <!-- Link Reference Definitions -->
 [`Install-Vale`]: /modules/vale/reference/cmdlets/install-vale
-
-<!-- Release Links -->
-[0.1.0]: https://github.com/microsoft/Documentarian/releases/tag/Documentarian.Vale%2Fv0.1.0
-[0.0.1]: https://github.com/microsoft/Documentarian/releases/tag/Documentarian.Vale%2Fv0.0.1

--- a/Projects/Modules/Documentarian/CHANGELOG.md
+++ b/Projects/Modules/Documentarian/CHANGELOG.md
@@ -15,19 +15,31 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Modules/Documentarian
+  with_labels:
+    - Documentarian
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
+Related Links
+: {{< changelog/link/prs after="2023-03-27" >}}
+
 ### Fixed
 
-- Ensure that `Convert-MDLinks` correctly handles all matches found by the regex patterns.
+- Ensure that [`Convert-MDLinks`] correctly handles all matches found by the regex patterns.
 
-## [0.0.1] - 2023-03-27
+## 0.0.1 - 2023-03-27
+
+Related Links
+: {{< changelog/link/source tag="Documentarian/v0.0.1" >}}
 
 ### Added
 
 - Initial release.
 
-<!-- link references -->
-[0.0.1]: https://github.com/microsoft/Documentarian/releases/tag/Documentarian%2Fv0.0.1
+<!-- Link Reference Definitions -->
+[`Convert-MDLinks`]: /modules/documentarian/reference/cmdlets/convert-mdlinks

--- a/Projects/Styles/PowerShell-Docs/CHANGELOG.md
+++ b/Projects/Styles/PowerShell-Docs/CHANGELOG.md
@@ -15,8 +15,21 @@ description: |
 
   [01]: https://keepachangelog.com/en/1.0.0/
   [02]: https://semver.org/spec/v2.0.0.html
+release_links:
+  source_path: Projects/Styles/PowerShell-Docs
+  with_labels:
+    - style-PowerShell-Docs
+  skip_labels:
+    - maintenance
 ---
 
 ## Unreleased
 
+Related Links
+: {{< changelog/link/prs after="2022-10-14" >}}
+
+### Added
+
 - Scaffolded initial project.
+
+<!-- Link Reference Definitions -->


### PR DESCRIPTION
# PR Summary

This change adds new shortcodes to the docsy-pwsh Hugo module for easier changelog link writing.

The `changelog/link/source` shortcode adds a link to the source code for a given tagged release, using the repository, tag, and source path.

The `changelog/link/prs` shortcode adds a link to the pull requests for a given release, building the pull request search query so the source does not need to include the unreadable URL queries.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
