### PR TITLE
(MAINT) Minor updates for Vale demo

### DIFF
--- a/Projects/Modules/Documentarian.Vale/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.Vale/CHANGELOG.md
@@ -28,6 +28,17 @@ release_links:
 Related Links
 : {{< changelog/link/prs after="2023-04-06" >}}
 
+### Added
+
+- Extended verbose output for [`New-ValeConfiguration`]to provide information about the created
+  configuration file and adding messaging for the configuration's initial sync.
+
+### Fixed
+
+- Corrected the scoring for the `GunningFog` rule, ensuring that results for the
+  [`Get-ProseReadability`] command are right. Before this fix, the command would sometimes return
+  an invalid negative score.
+
 ## 0.1.0 - 2023-04-06
 
 Related Links
@@ -54,4 +65,6 @@ Related Links
 - Initial release.
 
 <!-- Link Reference Definitions -->
-[`Install-Vale`]: /modules/vale/reference/cmdlets/install-vale
+[`Install-Vale`]:          /modules/vale/reference/cmdlets/install-vale
+[`New-ValeConfiguration`]: /modules/vale/reference/cmdlets/new-valeconfiguration
+[`Get-ProseReadability`]:  /modules/vale/reference/cmdlets/get-prosereadability

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeMetricsGunningFog.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeMetricsGunningFog.psm1
@@ -38,9 +38,9 @@ class ValeMetricsGunningFog : ValeReadability {
     }
 
     static [float] GetScore([ValeMetricsInfo]$Metrics) {
-        $Result = 0.4 * ($Metrics.WordCount / $Metrics.SentenceCount)
+        $Result = $Metrics.WordCount / $Metrics.SentenceCount
         $Result += 100 * ($Metrics.ComplexWordCount / $Metrics.WordCount)
-        $Result -= 15.59
+        $Result *= 0.4
 
         return $Result
     }

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeMetricsSMOG.psm1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Classes/ValeMetricsSMOG.psm1
@@ -53,7 +53,9 @@ class ValeMetricsSMOG : ValeReadability {
     }
 
     static [float] GetScore([ValeMetricsInfo]$Metrics) {
-        $Result = 1.043 * [Math]::Sqrt($Metrics.ComplexWordCount * 30 / $Metrics.SentenceCount)
+        $Result = $Metrics.ComplexWordCount * 30 / $Metrics.SentenceCount
+        $Result = [Math]::Sqrt($Result)
+        $Result *= 1.0430
         $Result += 3.1291
 
         return $Result


### PR DESCRIPTION
# PR Summary

This change makes minor improvements to **Documentarian.Vale** to support recording a demo that uses the module.

It fixes an error in the scoring for the `GunningFog` rule and extends the verbose messaging in `New-ValeConfiguration`. It also updates the `SMOG` rule for easier reading/maintenance.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
