### PR TITLE
(GH-115) Replace powershell-yaml dep with YaYaml

### DIFF
--- a/Projects/Modules/.sync.ps1
+++ b/Projects/Modules/.sync.ps1
@@ -49,7 +49,7 @@ begin {
   )
 
   $Modules = @(
-    @{ Name = 'powershell-yaml' }
+    @{ Name = 'YaYaml' }
 
     @{
       Name           = 'InvokeBuild'

--- a/Projects/Modules/Documentarian.Vale/.DevX.jsonc
+++ b/Projects/Modules/Documentarian.Vale/.DevX.jsonc
@@ -11,7 +11,8 @@
     "Description": "Collection of tools for installing and using the Vale prose linter.",
     "PowerShellVersion": "7.2",
     "RequiredModules": [
-      "PsIni"
+      "PsIni",
+      "YaYaml"
     ],
     "Tags": [
       "Markdown",

--- a/Projects/Modules/Documentarian.Vale/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.Vale/CHANGELOG.md
@@ -28,6 +28,14 @@ release_links:
 Related Links
 : {{< changelog/link/prs after="2023-04-06" >}}
 
+### Added
+
+### Changed
+
+- Replaced an implicit dependency on the [powershell-yaml] module with an explicit dependency on
+  [YaYaml] - this resolves the YamlDotNet dependency conflict that prevents the module from being
+  used with PlatyPS. Only the dependency is changed, not the functionality.
+
 ## 0.2.0 - 2023-04-26
 
 Related Links
@@ -74,3 +82,5 @@ Related Links
 [`Install-Vale`]:          /modules/vale/reference/cmdlets/install-vale
 [`New-ValeConfiguration`]: /modules/vale/reference/cmdlets/new-valeconfiguration
 [`Get-ProseReadability`]:  /modules/vale/reference/cmdlets/get-prosereadability
+[powershell-yaml]:   https://github.com/cloudbase/powershell-yaml
+[YaYaml]:            https://github.com/jborean93/PowerShell-Yayaml

--- a/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Get-ValeStyle.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/Functions/Get-ValeStyle.ps1
@@ -51,7 +51,8 @@ function Get-ValeStyle {
             $rules = @()
             foreach ($rulename in $rulenames) {
                 $rule = [ValeRule]::new($style.Name, $rulename.BaseName, $rulename.FullName)
-                $rule.Properties = Get-Content -Path $rulename.FullName | ConvertFrom-Yaml -Ordered
+                $rule.Properties = Get-Content -Path $rulename.FullName |
+                    YaYaml\ConvertFrom-Yaml
                 $rules += $rule
             }
             $style.Rules = $rules

--- a/Projects/Modules/Documentarian/.DevX.jsonc
+++ b/Projects/Modules/Documentarian/.DevX.jsonc
@@ -11,7 +11,7 @@
     "Description": "Collection of general purpose functions for working with Markdown documents.",
     "PowerShellVersion": "7.2",
     "RequiredModules": [
-      "PowerShell-Yaml"
+      "YaYaml"
     ],
     "ScriptsToProcess": "Init.ps1",
     "VariablesToExport": "*",

--- a/Projects/Modules/Documentarian/CHANGELOG.md
+++ b/Projects/Modules/Documentarian/CHANGELOG.md
@@ -28,6 +28,12 @@ release_links:
 Related Links
 : {{< changelog/link/prs after="2023-03-27" >}}
 
+### Changed
+
+- Replaced dependency on the [powershell-yaml] module with [YaYaml] - this resolves the YamlDotNet
+  dependency conflict that prevents the module from being used with PlatyPS. Only the dependency is
+  changed, not the functionality.
+
 ### Fixed
 
 - Ensure that [`Convert-MDLinks`] correctly handles all matches found by the regex patterns.
@@ -43,3 +49,5 @@ Related Links
 
 <!-- Link Reference Definitions -->
 [`Convert-MDLinks`]: /modules/documentarian/reference/cmdlets/convert-mdlinks
+[powershell-yaml]:   https://github.com/cloudbase/powershell-yaml
+[YaYaml]:            https://github.com/jborean93/PowerShell-Yayaml

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-Document.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-Document.ps1
@@ -61,7 +61,7 @@ function Get-Document {
 
       if ($FrontMatterToken) {
         $ParsedDocumentParameters.FrontMatter = $FrontMatterToken.Lines.ToString().Trim()
-        | ConvertFrom-Yaml -Ordered
+        | YaYaml\ConvertFrom-Yaml
 
         $Body = $ParsedDocumentParameters.RawContent -split '---'
         | Select-Object -Skip 2


### PR DESCRIPTION
# PR Summary

Prior to this change, the **Documentarian** module had an explicit dependency on the **powershell-yaml** module and **Documentarian.Vale** had an implicit dependency.

This dependency caused a conflict with **PlatyPS**, which also depends on the YamlDotNet library that **powershell-yaml** uses. This conflict prevented the modules from working correctly for normal workflows like exporting and updating documentation. It also meant that anyone loading either of these modules was prevented from loading PlatyPS in the same session.

This change replaces the dependency on **powershell-yaml** with the **YaYaml** module instead. **YaYaml** uses an assembly load context to load the YamlDotNet library, preventing the conflict.

This change should make the modules more functional, no longer requiring users to operate in two different sessions to manage their PowerShell documentation.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
