### PR TITLE
Update `Get-CmdletXref.ps1` to support input from `Get-Command`

### DIFF
--- a/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/CommandInfoArgumentTransformation.ps1
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/CommandInfoArgumentTransformation.ps1
@@ -1,0 +1,26 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using namespace System.Management.Automation
+
+class CommandInfoArgumentTransformation : ArgumentTransformationAttribute {
+    [Object] Transform([EngineIntrinsics] $engineIntrinsics, [Object] $inputData) {
+        $cmd = $inputData
+
+        if ($inputData -isnot [CommandInfo]) {
+            $cmd = $engineIntrinsics.InvokeCommand.GetCommand(
+                [string] $inputData,
+                [CommandTypes]::All)
+        }
+
+        if (-not $cmd) {
+            throw [CommandNotFoundException]::new("Unable to find command '$inputData'.")
+        }
+
+        if ($cmd.CommandType -eq [CommandTypes]::Alias) {
+            return $cmd.ResolvedCommand
+        }
+
+        return $cmd
+    }
+}

--- a/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Functions/Get-CmdletXref.ps1
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Functions/Get-CmdletXref.ps1
@@ -15,7 +15,10 @@ function Get-CmdletXref {
         [Parameter(Mandatory, ValueFromPipeline)]
         [object[]] $Command
     )
-
+    
+    begin {
+        $allowedFlags = [CommandTypes] 'Cmdlet, Function, Filter'
+    }
     process {
         foreach ($cmd in $Command) {
             try {
@@ -40,7 +43,7 @@ function Get-CmdletXref {
                 $commandname = $cmd.Name
                 $commandtype = $cmd.CommandType
 
-                if (($commandtype -band [CommandTypes] 'Cmdlet, Function, Filter') -eq 0) {
+                if (-not $allowedFlags.HasFlag($commandtype)) {
                     $PSCmdlet.WriteWarning("'$commandname' is a(n) $commandtype.")
                     continue
                 }

--- a/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Functions/Get-CmdletXref.ps1
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Functions/Get-CmdletXref.ps1
@@ -13,7 +13,8 @@ function Get-CmdletXref {
     param(
         # The name of the Command or a CommandInfo instance to get a cross-reference link for.
         [Parameter(Mandatory, ValueFromPipeline)]
-        [object[]] $Command
+        [CommandInfoArgumentTransformation()]
+        [CommandInfo[]] $Command
     )
 
     begin {
@@ -26,23 +27,6 @@ function Get-CmdletXref {
     process {
         foreach ($cmd in $Command) {
             try {
-                if ($cmd -isnot [CommandInfo]) {
-                    $tryGetCommand = $PSCmdlet.InvokeCommand.GetCommand(
-                        $cmd,
-                        [CommandTypes]::All)
-
-                    if (-not $tryGetCommand) {
-                        throw [CommandNotFoundException]::new("Unable to find command '$cmd'.")
-                    }
-
-                    $cmd = $tryGetCommand
-                }
-
-                if ($cmd.CommandType -eq [CommandTypes]::Alias) {
-                    $cmd = $cmd.ResolvedCommand
-                    $PSCmdlet.WriteVerbose("$commandname is an alias for $($cmd.Name).")
-                }
-
                 $modulename = $cmd.ModuleName
                 $commandname = $cmd.Name
                 $commandtype = $cmd.CommandType

--- a/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Functions/Get-CmdletXref.ps1
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Functions/Get-CmdletXref.ps1
@@ -15,7 +15,7 @@ function Get-CmdletXref {
         [Parameter(Mandatory, ValueFromPipeline)]
         [object[]] $Command
     )
-    
+
     begin {
         $allowedFlags = [CommandTypes]@(
             'Cmdlet'
@@ -65,11 +65,9 @@ function Get-CmdletXref {
                 }
 
                 "[$commandname](xref:${modulename}.$commandname)"
-            }
-            catch [CommandNotFoundException] {
+            } catch [CommandNotFoundException] {
                 $PSCmdlet.WriteWarning($_)
-            }
-            catch {
+            } catch {
                 $PSCmdlet.WriteError($_)
             }
         }


### PR DESCRIPTION
# PR Summary

This PR adds pipeline support for `Get-Command`, should solve #125.

Worth noting, the function was already able to take input from `Get-Command` because `CommandInfo` instances when coerced to a string resolve in their `.Name` property, but the code as-is, would query the command again making it not very efficient, thus the change to `[object[]]` in the parameter type and the check for `$cmd -isnot [CommandInfo]`.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
