### PR TITLE
Update Get-LocaleFreshness to support more locales

### DIFF
--- a/Projects/Modules/Documentarian.MicrosoftDocs/.DevX.jsonc
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/.DevX.jsonc
@@ -1,7 +1,7 @@
 {
   "ManifestData": {
     "Guid": "a054ec31-cb69-4a4b-b66b-39d25e909615",
-    "ModuleVersion": "0.0.2",
+    "ModuleVersion": "0.0.3",
     "RootModule": "Documentarian.MicrosoftDocs.psm1",
     "ScriptsToProcess": "Init.ps1",
     "VariablesToExport": "*",

--- a/Projects/Modules/Documentarian.MicrosoftDocs/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/CHANGELOG.md
@@ -25,6 +25,8 @@ release_links:
 
 ## Unreleased
 
+- Add new class for `Get-LocaleFreshness` to define lists of default and supported locales.
+
 - Added [`Get-CmdletXref`] to make it simpler to add links to cmdlet reference docs.
 
 [`Get-CmdletXref`]: /modules/microsoftdocs/reference/cmdlets/get-cmdletxref/

--- a/Projects/Modules/Documentarian.MicrosoftDocs/Documentation/reference/cmdlets/Get-LocaleFreshness.md
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Documentation/reference/cmdlets/Get-LocaleFreshness.md
@@ -15,7 +15,7 @@ Gets the `ms.date` metadata information of a Docs article for every locale.
 ## SYNTAX
 
 ```
-Get-LocaleFreshness [-Uri] <uri> [[-Locales] <string[]>] [<CommonParameters>]
+Get-LocaleFreshness [-Uri] <uri> [[-Locale] <string[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,6 +23,8 @@ Get-LocaleFreshness [-Uri] <uri> [[-Locales] <string[]>] [<CommonParameters>]
 Gets the `ms.date` metadata information of a Docs article for every locale. The output includes the
 locale information and the translation method. This is useful to see that the localization process
 has picked up the latest changes made to the English version of the article.
+
+For comparison, the output of the cmdlet always includes the English version of the article.
 
 ## EXAMPLES
 
@@ -80,8 +82,9 @@ Get-LocaleFreshness $url pt-br, pt-pt
 ```Output
 locpath locale ms.contentlocale ms.translationtype ms.date    loc_version                  updated_at
 ------- ------ ---------------- ------------------ -------    -----------                  ----------
-pt-br   pt-br  pt-br            HT                 05/31/2022 2022-07-18T20:00:40.4523397Z 2022-08-17 10:12 PM
-pt-pt   pt-pt  pt-pt            MT                 05/31/2022 2022-07-18T20:00:40.4523397Z 2022-08-17 10:12 PM
+en-us   en-us                                      01/09/2023                              2023-09-05 09:55 PM
+pt-br   pt-br  pt-br            HT                 01/09/2023 2023-09-26T22:04:42.7240190Z 2023-10-13 11:23 PM
+pt-pt   pt-pt  pt-pt            MT                 01/09/2023 2023-10-26T21:59:59.7444562Z 2023-10-26 11:59 PM
 ```
 
 ### Example 3 - Get the full freshness data for an article for select languages
@@ -94,48 +97,51 @@ Get-LocaleFreshness $url pt-br | Format-List -Property *
 ```
 
 ```Output
+locpath                  : en-us
+locale                   : en-us
+ms.contentlocale         :
+ms.translationtype       :
+ms.date                  : 01/09/2023
+loc_version              :
+updated_at               : 2023-09-05 09:55 PM
+loc_source_id            :
+loc_file_id              :
+original_content_git_url : https://github.com/MicrosoftDocs/PowerShell-Docs/blob/live/reference/docs-conceptual/install/In
+                           stalling-PowerShell-on-Linux.md
+
 locpath                  : pt-br
 locale                   : pt-br
 ms.contentlocale         : pt-br
 ms.translationtype       : HT
-ms.date                  : 05/31/2022
-loc_version              : 2022-07-18T20:00:40.4523397Z
-updated_at               : 2022-08-17 10:12 PM
+ms.date                  : 01/09/2023
+loc_version              : 2023-09-26T22:04:42.7240190Z
+updated_at               : 2023-10-13 11:23 PM
 loc_source_id            : Github-44411511#live
-loc_file_id              : Github-44411511.live.PowerShell.PowerShell_PowerShell-docs_reference.docs-conceptual/install
-                           /Installing-PowerShell-on-Linux.md
-original_content_git_url : https://github.com/MicrosoftDocs/PowerShell-Docs/blob/live/reference/docs-conceptual/install
-                           /Installing-PowerShell-on-Linux.md
+loc_file_id              : Github-44411511.live.PowerShell.PowerShell_PowerShell-docs_reference.docs-conceptual/install/In
+                           stalling-PowerShell-on-Linux.md
+original_content_git_url : https://github.com/MicrosoftDocs/PowerShell-Docs/blob/live/reference/docs-conceptual/install/In
+                           stalling-PowerShell-on-Linux.md
 ```
 
 ## PARAMETERS
 
-### -Locales
+### -Locale
 
 An array of one or more locale strings. The parameter default defaults to the following array of
 values:
 
-- `en-us`
-- `cs-cz`
-- `de-de`
-- `es-es`
-- `fr-fr`
-- `hu-hu`
-- `id-id`
-- `it-it`
-- `ja-jp`
-- `ko-kr`
-- `nl-nl`
-- `pl-pl`
-- `pt-br`
-- `pt-pt`
-- `ru-ru`
-- `sv-se`
-- `tr-tr`
-- `zh-cn`
-- `zh-tw`
+- `ar-sa`, `cs-cz`, `de-de`, `en-us`, `es-es`, `fr-fr`, `hu-hu`, `id-id`, `it-it`, `ja-jp`, `ko-kr`,
+  `nl-nl`, `pl-pl`, `pt-br`, `pt-pt`, `ru-ru`, `sv-se`, `tr-tr`, `zh-cn`, `zh-tw`
 
-The value can be any valid locale identifier string.
+The value can be any of the locales supported by the docs platform:
+
+- `ar-sa`, `bg-bg`, `bs-latn-ba`, `ca-es`, `cs-cz`, `da-dk`, `de-at`, `de-ch`, `de-de`, `el-gr`,
+  `en-au`, `en-ca`, `en-gb`, `en-ie`, `en-in`, `en-my`, `en-nz`, `en-sg`, `en-us`, `en-za`, `es-es`,
+  `es-mx`, `et-ee`, `eu-es`, `fi-fi`, `fil-ph`, `fr-be`, `fr-ca`, `fr-ch`, `fr-fr`, `ga-ie`,
+  `gl-es`, `he-il`, `hi-in`, `hr-hr`, `hu-hu`, `id-id`, `is-is`, `it-ch`, `it-it`, `ja-jp`, `ka-ge`,
+  `kk-kz`, `ko-kr`, `lb-lu`, `lt-lt`, `lv-lv`, `ms-my`, `mt-mt`, `nb-no`, `nl-be`, `nl-nl`, `pl-pl`,
+  `pt-br`, `pt-pt`, `ro-ro`, `ru-ru`, `sk-sk`, `sl-si`, `sr-cyrl-rs`, `sr-latn-rs`, `sv-se`,
+  `th-th`, `tr-tr`, `uk-ua`, `vi-vn`, `zh-cn`, `zh-hk`, `zh-tw`
 
 ```yaml
 Type: System.String[]
@@ -144,14 +150,14 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: en-us, cs-cz, de-de, es-es, fr-fr, hu-hu, id-id, it-it, ja-jp, ko-kr, nl-nl, pl-pl, pt-br, pt-pt, ru-ru, sv-se, tr-tr, zh-cn, zh-tw
+Default value: 'ar-sa', 'en-us', 'cs-cz', 'de-de', 'es-es', 'fr-fr', 'hu-hu', 'id-id', 'it-it', 'ja-jp', 'ko-kr', 'nl-nl', 'pl-pl', 'pt-br', 'pt-pt', 'ru-ru', 'sv-se', 'tr-tr', 'zh-cn', 'zh-tw'
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Uri
 
-The URL to the article being inspected. The URL must contain a locale.
+The URL to the article being inspected. The URL must contain a supported locale.
 
 ```yaml
 Type: System.Uri
@@ -187,5 +193,7 @@ The other properties are values of HTML `<meta>` tags in the published articles.
 tags are set by the build system when the article is published.
 
 ## NOTES
+
+This cmdlet depends on the `Get-HtmlMetaTags` cmdlet.
 
 ## RELATED LINKS

--- a/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/.LoadOrder.jsonc
@@ -6,4 +6,9 @@
     //     "IgnoreForBuild": false,
     //     "IgnoreForTest": false
     // }
+    {
+        "Name": "LearnLocales",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": true
+    }
 ]

--- a/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/LearnLocales.psm1
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/LearnLocales.psm1
@@ -1,4 +1,7 @@
-﻿class LearnLocales {
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+class LearnLocales {
 
     ## This list of locales is based on the language selection page on the Learn platform.
 

--- a/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/LearnLocales.psm1
+++ b/Projects/Modules/Documentarian.MicrosoftDocs/Source/Public/Classes/LearnLocales.psm1
@@ -1,0 +1,20 @@
+﻿class LearnLocales {
+
+    ## This list of locales is based on the language selection page on the Learn platform.
+
+    static [string[]]$SupportedLocales = 'ar-sa', 'bg-bg', 'bs-latn-ba', 'ca-es', 'cs-cz', 'da-dk',
+    'de-at', 'de-ch', 'de-de', 'el-gr', 'en-au', 'en-ca', 'en-gb', 'en-ie', 'en-in', 'en-my',
+    'en-nz', 'en-sg', 'en-us', 'en-za', 'es-es', 'es-mx', 'et-ee', 'eu-es', 'fi-fi', 'fil-ph',
+    'fr-be', 'fr-ca', 'fr-ch', 'fr-fr', 'ga-ie', 'gl-es', 'he-il', 'hi-in', 'hr-hr', 'hu-hu',
+    'id-id', 'is-is', 'it-ch', 'it-it', 'ja-jp', 'ka-ge', 'kk-kz', 'ko-kr', 'lb-lu', 'lt-lt',
+    'lv-lv', 'ms-my', 'mt-mt', 'nb-no', 'nl-be', 'nl-nl', 'pl-pl', 'pt-br', 'pt-pt', 'ro-ro',
+    'ru-ru', 'sk-sk', 'sl-si', 'sr-cyrl-rs', 'sr-latn-rs', 'sv-se', 'th-th', 'tr-tr', 'uk-ua',
+    'vi-vn', 'zh-cn', 'zh-hk', 'zh-tw'
+
+    ## Most docs are trnaslated into a subset of 19 locales.
+
+    static [string[]]$CommonLocales = 'ar-sa', 'en-us', 'cs-cz', 'de-de', 'es-es', 'fr-fr', 'hu-hu',
+    'id-id', 'it-it', 'ja-jp', 'ko-kr', 'nl-nl', 'pl-pl', 'pt-br', 'pt-pt', 'ru-ru', 'sv-se',
+    'tr-tr', 'zh-cn', 'zh-tw'
+
+}


### PR DESCRIPTION
Update Get-LocaleFreshness to support more locales

This PR adds a class with static members:
- `$SupportedLocales` - a list of locales supported by the Learn platform
- `$CommonLocales` - the 19 most common locales that our docs are translated into

The cmdlet was updated to validate against the full list but default to the common list.

This PR bumps the module version to 0.0.3.