### PR TITLE
(GH-133) Add argument completer handling to DevX

### DIFF
--- a/Projects/Modules/Documentarian.DevX/Source/Private/Functions/Resolve-NameSpace.ps1
+++ b/Projects/Modules/Documentarian.DevX/Source/Private/Functions/Resolve-NameSpace.ps1
@@ -92,6 +92,7 @@ function Resolve-NameSpace {
 
     if ([string]::IsNullOrEmpty($ParentNameSpace)) {
       $ParentNameSpace = switch ($Category) {
+        ArgumentCompleter { "ArgumentCompleters.$Scope" }
         Class { "Classes.$Scope" }
         Enum { "Enums.$Scope" }
         Function { "Functions.$Scope" }

--- a/Projects/Modules/Documentarian.DevX/Source/Public/Classes/SourceFolder.psm1
+++ b/Projects/Modules/Documentarian.DevX/Source/Public/Classes/SourceFolder.psm1
@@ -77,7 +77,6 @@ class SourceFolder {
         | Where-Object -FilterScript { $_ -notmatch '^\s*\/\/' }
         | ConvertFrom-Json
 
-        
         foreach ($Item in $LoadOrder) {
           $ItemFileName = "$($Item.Name).psm1"
           $ItemPath = if ([string]::IsNullOrEmpty($Item.Folder)) {
@@ -85,15 +84,14 @@ class SourceFolder {
           } else {
             Join-Path -Path $BasePath -ChildPath $Item.Folder -AdditionalChildPath $ItemFileName
           }
-          
+
           try {
             $ItemPath | Resolve-Path | ForEach-Object {
               [SourceFile]::new($this.NameSpace, $_.Path)
             }
-          }
-          catch {
+          } catch {
             $Message = @(
-              "Unable to resolve source file from LoadOrder at '$ITemPath'"
+              "Unable to resolve source file from LoadOrder at '$ItemPath'"
               "from configured options: $($Item | ConvertTo-Json)"
             ) -join ' '
             throw [System.IO.FileNotFoundException]::New($Message, $_.Exception)
@@ -101,7 +99,7 @@ class SourceFolder {
         }
       }
       $false {
-        Get-ChildItem -Path $BasePath -Include '*.ps1*' -Exclude '*.Tests.ps1' -Recurse
+        Get-ChildItem -Path $BasePath -Include '*.ps1*', '*.psd1' -Exclude '*.Tests.ps1' -Recurse
         | ForEach-Object -Process {
           [SourceFile]::new($this.NameSpace, $_.FullName)
         }

--- a/Projects/Modules/Documentarian.DevX/Source/Public/Enums/SourceCategory.psm1
+++ b/Projects/Modules/Documentarian.DevX/Source/Public/Enums/SourceCategory.psm1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 enum SourceCategory {
+  ArgumentCompleter
   Class
   Enum
   Function

--- a/Projects/Modules/Documentarian.DevX/Source/Public/Functions/General/Get-SourceFolder.ps1
+++ b/Projects/Modules/Documentarian.DevX/Source/Public/Functions/General/Get-SourceFolder.ps1
@@ -24,7 +24,7 @@ function Get-SourceFolder {
   param(
     [Parameter(Mandatory, ParameterSetName = 'ByOption')]
     [Parameter(ParameterSetName = 'WithSpecificFolders')]
-    [ValidateSet('Classes', 'Enums', 'Formats', 'Functions', 'Tasks', 'Types')]
+    [ValidateSet('ArgumentCompleters', 'Classes', 'Enums', 'Formats', 'Functions', 'Tasks', 'Types')]
     [string[]]$Category,
 
     [Parameter(Mandatory, ParameterSetName = 'ByOption')]
@@ -34,7 +34,7 @@ function Get-SourceFolder {
 
     [Parameter(ParameterSetName = 'ByPreset')]
     [Parameter(ParameterSetName = 'WithSpecificFolders')]
-    [ValidateSet('Ordered', 'Functions', 'PS1Xmls', 'Tasks', 'All')]
+    [ValidateSet('Ordered', 'Functions', 'PS1Xmls', 'PSD1s', 'Tasks', 'All')]
     [string]$Preset = 'All',
 
     [Parameter(ParameterSetName = 'ByPreset')]
@@ -54,7 +54,7 @@ function Get-SourceFolder {
   )
 
   process {
-    $Category ??= @('Classes', 'Enums', 'Formats', 'Functions', 'Tasks', 'Types')
+    $Category ??= @('ArgumentCompleters', 'Classes', 'Enums', 'Formats', 'Functions', 'Tasks', 'Types')
     $CategoryPattern = "\b$($Category -join '|')\b"
     if ($SourceFolder) {
       $PublicFolder = Join-Path -Path $SourceFolder -ChildPath 'Public'
@@ -94,6 +94,12 @@ function Get-SourceFolder {
         )
       }
 
+      'PSD1s' {
+        @(
+          Join-Path -Path $PublicFolder -ChildPath ArgumentCompleters
+        )
+      }
+
       'Tasks' {
         @(
           Join-Path -Path $PublicFolder -ChildPath Tasks
@@ -111,6 +117,7 @@ function Get-SourceFolder {
           Join-Path -Path $PublicFolder -ChildPath Formats
           Join-Path -Path $PublicFolder -ChildPath Tasks
           Join-Path -Path $PublicFolder -ChildPath Types
+          Join-Path -Path $PublicFolder -ChildPath ArgumentCompleters
         )
       }
 

--- a/Projects/Modules/Documentarian.DevX/Source/Public/Functions/General/New-ArgumentCompleterDefinition.ps1
+++ b/Projects/Modules/Documentarian.DevX/Source/Public/Functions/General/New-ArgumentCompleterDefinition.ps1
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function New-ArgumentCompleterDefinition {
+    [CmdletBinding()]
+    param(
+        [string[]]$Path = './ArgumentCompleter.psd1',
+        [string]$CopyrightNotice,
+        [string]$LicenseNotice,
+        [string[]]$CommandName,
+        [string]$ParameterName,
+        [scriptblock]$ScriptBlock,
+        [switch]$Native,
+        [switch]$Force
+    )
+
+    begin {
+        $Content = @()
+        # Handle adding notices to the top of the file, if needed.
+        $HasCopyrightNotice = -not [string]::IsNullOrEmpty($CopyrightNotice)
+        $HasLicenseNotice = -not [string]::IsNullOrEmpty($LicenseNotice)
+        if ($HasCopyrightNotice) { $Content += "# $CopyrightNotice" }
+        if ($HasLicenseNotice) { $Content += "# $LicenseNotice" }
+        if ($HasCopyrightNotice -or $HasLicenseNotice) { $Content += '' }
+
+        # Add contextual help for future editors of the file.
+        $Content += @(
+            '# The key-value pairs are parameters for the Register-ArgumentCompleter cmdlet.'
+            '# For more information, run `Get-Help Register-ArgumentCompleter` or see:'
+            '# https://learn.microsoft.com/powershell/module/microsoft.powershell.core/register-argumentcompleter'
+        )
+
+        $PowerShellCommandParamBlock = @(
+            '        param('
+            '            $commandName,'
+            '            $parameterName,'
+            '            $wordToComplete,'
+            '            $commandAst,'
+            '            $fakeBoundParameters'
+            '        )'
+        ) -join "`n"
+        $NativeCommandParamBlock = @(
+            '        param('
+            '            $wordToComplete,'
+            '            $commandAst,'
+            '            $cursorPosition'
+            '        )'
+        ) -join "`n"
+
+        $Content += @(
+            '@{'
+            "    CommandName   = '$($CommandName -join "', '")'"
+            "    ParameterName = '$ParameterName'"
+            '    ScriptBlock   = {'
+            ($Native ? $NativeCommandParamBlock : $PowerShellCommandParamBlock)
+            ''
+            '        # Script block body here.'
+            ''
+            '    }'
+            '}'
+        )
+
+        $Content = $Content -join "`n"
+    }
+
+    process {
+        if ($null -ne $ScriptBlock) {
+            # Parse the script block to get the parameter names, make sure they're correct.
+            $ParameterNames = $ScriptBlock.Ast.ParamBlock.Parameters.Name
+            $ParameterCount = $ParameterNames.Count
+            $ExpectedParameterCount = $Native ? 3 : 5
+            if ($ParameterCount -ne $ExpectedParameterCount) {
+                $ErrorMessage = @(
+                    "The scriptblock must have $ExpectedParameterCount parameters,"
+                    "but only had $ParameterCount ($($ParameterNames -join ', '))."
+                    'Use the following parameter block for the scriptblock.'
+                    "`n"
+                    ($Native ? $NativeCommandParamBlock : $PowerShellCommandParamBlock)
+                    "`n"
+                    'For more information, see the Register-ArgumentCompleter cmdlet.'
+                ) -join ' '
+            }
+            $PSCmdlet.ThrowTerminatingError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    [System.ArgumentException]::new($ErrorMessage),
+                    'InvalidArgumentCompleterScriptBlock',
+                    'InvalidArgumentCompleter',
+                    $null
+                )
+            )
+        }
+
+        if ((Test-Path -Path $Path) -and -not $Force) {
+            $Message = @(
+                "The file '$((Get-Item $Path).FullName)' already exists."
+                'Use the -Force switch to overwrite the file.'
+            ) -join ' '
+            $PSCmdlet.ThrowTerminatingError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    [System.IO.IOException]::new($Message),
+                    'FileAlreadyExists',
+                    'ResourceExists',
+                    $null
+                )
+            )
+        }
+
+        $File = New-Item -Path $Path -ItemType File -Force
+        $Content | Out-File -FilePath $File -Encoding utf8NoBOM -Force
+        $File
+    }
+}

--- a/Projects/Modules/Documentarian.Vale/Source/Init.ps1
+++ b/Projects/Modules/Documentarian.Vale/Source/Init.ps1
@@ -13,26 +13,3 @@
     obviate the need to remember to call the `using` statement on the
     module and ensures the public classes and enums are available.
 #>
-
-$PackageNameCompleter = {
-  param(
-    $commandName,
-    $parameterName,
-    $wordToComplete,
-    $commandAst,
-    $fakeBoundParameters
-  )
-
-  [ValeKnownStylePackage].GetEnumNames() | Where-Object {
-    $_ -like "$wordToComplete*"
-  } | ForEach-Object {
-    $_
-  }
-}
-
-$PackageNameCompleterParams = @{
-  CommandName   = 'New-ValeConfiguration'
-  ParameterName = 'StylePackage'
-  ScriptBlock   = $PackageNameCompleter
-}
-Register-ArgumentCompleter @PackageNameCompleterParams

--- a/Projects/Modules/Documentarian.Vale/Source/Public/ArgumentCompleters/PackageNameCompleter.psd1
+++ b/Projects/Modules/Documentarian.Vale/Source/Public/ArgumentCompleters/PackageNameCompleter.psd1
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# The key-value pairs are parameters for the Register-ArgumentCompleter cmdlet.
+# For more information, run `Get-Help Register-ArgumentCompleter` or see:
+# https://learn.microsoft.com/powershell/module/microsoft.powershell.core/register-argumentcompleter
+@{
+    CommandName   = 'New-ValeConfiguration'
+    ParameterName = 'StylePackage'
+    ScriptBlock   = {
+        param(
+            $commandName,
+            $parameterName,
+            $wordToComplete,
+            $commandAst,
+            $fakeBoundParameters
+        )
+
+        [ValeKnownStylePackage].GetEnumNames() | Where-Object {
+            $_ -like "$wordToComplete*"
+        } | ForEach-Object {
+            $_
+        }
+    }
+}


### PR DESCRIPTION


# PR Summary

Prior to this change, the **Documentarian.DevX** module didn't have built-in handling for defining and registering argument completers. Instead, it relied on the developers defining them in the initialization script.

Argument completers can be registered in the body of the root module. Adding them there from a discoverable source folder means that they're easier to maintain and discover, and reduces the need for an initialization script.

This change:

- Adds the new **SourceCategory**, `ArgumentCompleter`.
- Updates the implementation for the **SourceFile**, **SourceFolder**, and **ModuleComposer** classes to handle argument completer files.

  It defines the standard layout folder for them as `Source/Public/ArgumentCompleters` and expects each file to be a defined `*.psd1` file with a hashtable of the parameters to pass to the `Register-ArgumentCompleter` cmdlet.

  The **ModuleComposer** class now handles discovering argument completer definitions, arranging them into an array, and iteratively registering the defined argument completers in the root module through code generation.
- Adds `New-ArgumentCompleterDefinition` as a public function to make scaffolding the completers easier.
- Uses the new functionality to move the definition of the known style package argument completer for the **StylePackage** parameter of the `New-ValeConfiguration` function into a definition file, removing the code from the initialization script and thereby removing the need to ship an init script with the module.
- Resolves #133

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md
[style]: https://github.com/michaeltlombardi/DocumentarianModules/blob/main/CONTRIBUTING.md#Style
