### PR TITLE
Maint/main/helpinfo to methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,8 @@
         "Source/Hugo/*/public": true,
         "Source/Hugo/*/resources": true
     },
-    "vale.valeCLI.config": "${workspaceFolder}/.vale.ini"
+    "vale.valeCLI.config": "${workspaceFolder}/.vale.ini",
+    "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": false,
+    "powershell.codeFormatting.whitespaceBetweenParameters": false
 }

--- a/Projects/Modules/.CodeFormatting.psd1
+++ b/Projects/Modules/.CodeFormatting.psd1
@@ -1,0 +1,55 @@
+@{
+    IncludeRules = @(
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'PSUseConsistentWhitespace',
+        'PSUseConsistentIndentation',
+        'PSAlignAssignmentStatement',
+        'PSUseCorrectCasing'
+    )
+
+    Rules        = @{
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $false
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable              = $true
+            Kind                = 'space'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            IndentationSize     = 4
+        }
+
+        PSUseConsistentWhitespace  = @{
+            Enable                                  = $true
+            CheckInnerBrace                         = $true
+            CheckOpenBrace                          = $true
+            CheckOpenParen                          = $true
+            CheckOperator                           = $false
+            CheckPipe                               = $true
+            CheckPipeForRedundantWhitespace         = $false
+            CheckSeparator                          = $true
+            CheckParameter                          = $false
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+
+        PSUseCorrectCasing         = @{
+            Enable = $true
+        }
+    }
+}

--- a/Projects/Modules/.CodeFormatting.psd1
+++ b/Projects/Modules/.CodeFormatting.psd1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 @{
     IncludeRules = @(
         'PSPlaceOpenBrace',

--- a/Projects/Modules/Documentarian.DevX/Source/Public/Classes/SourceReference.psm1
+++ b/Projects/Modules/Documentarian.DevX/Source/Public/Classes/SourceReference.psm1
@@ -153,7 +153,7 @@ class SourceReference {
           ''
           '$SourceFolder = $PSScriptRoot'
           "while ('Source' -ne (Split-Path -Leaf `$SourceFolder)) {"
-          '  $SourceFolder = Split-Path -Parent -Path $SourceFolder'
+          '    $SourceFolder = Split-Path -Parent -Path $SourceFolder'
           '}'
           '$RequiredFunctions = @('
           $CommandReferences | ForEach-Object -Process {
@@ -161,11 +161,11 @@ class SourceReference {
             if ($FilePath -match "^$([regex]::Escape($SourceFolder))(?<ChildPath>.+)$") {
               $FilePath = "`$SourceFolder/$($Matches.ChildPath.Trim('\/') -replace '\\', '/')"
             }
-            "  Resolve-Path -Path `"$FilePath`""
+            "    Resolve-Path -Path `"$FilePath`""
           }
           ')'
           'foreach ($RequiredFunction in $RequiredFunctions) {'
-          '  . $RequiredFunction'
+          '    . $RequiredFunction'
           '}'
           ''
           '#endregion RequiredFunctions'

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/.LoadOrder.jsonc
@@ -12,7 +12,27 @@
         "IgnoreForTest": false
     },
     {
+        "Name": "MarkdownList",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "BulletList",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "NumberedList",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
         "Name": "CodeFenceCharacter",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "InlineFormatter",
         "IgnoreForBuild": false,
         "IgnoreForTest": false
     },

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/BulletList.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/BulletList.psm1
@@ -1,0 +1,286 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Enums/BulletListStyle.psm1
+using module ../Classes/MarkdownList.psm1
+
+class BulletList : MarkdownList {
+
+    static
+    [BulletListStyle]
+    $DefaultStyle = [BulletListStyle]::Hyphen
+
+    [BulletListStyle]
+    $Style
+
+    [string[]]
+    $Items
+
+    hidden Initialize([hashtable]$properties) {
+        <#
+            .SYNOPSIS
+                Initializes the BulletList object with default values.
+
+            .DESCRIPTION
+                Initializes the BulletList object with default values, setting the instance
+                **Style** to the value of the **DefaultStyle** static property and the **Items**
+                property an empty array.
+
+                This method is called by the constructors of the class before overriding these
+                defaults, if necessary.
+        #>
+
+        $this.Style = [BulletList]::DefaultStyle
+        $this.Items = @()
+
+        foreach ($key in $properties.Keys) {
+            $this.$key = $properties[$key]
+        }
+    }
+
+    BulletList() {
+        <#
+            .SYNOPSIS
+                Creates a new BulletList object with default values.
+
+            .DESCRIPTION
+                Creates a new BulletList object with default values. An instance of this class is
+                used to render items in a Markdown bullet list, handling indentation and bullet
+                style.
+        #>
+
+        $this.Initialize(@{})
+    }
+
+    BulletList([string[]]$items) {
+        <#
+            .SYNOPSIS
+                Creates a new BulletList object with the specified items.
+
+            .DESCRIPTION
+                Creates a new BulletList object with the specified items. An instance of this class
+                is used to render items in a Markdown bullet list, handling indentation and bullet
+                style.
+
+                Use this constructor when creating a top-level list. The style of the list is used
+                to determine the bullet style for the text.
+
+            .PARAMETER items
+                The items to add to the bullet list.
+        #>
+
+        $this.Initialize(@{ Items = $items })
+    }
+
+    BulletList([BulletListStyle]$Style) {
+        <#
+            .SYNOPSIS
+                Creates a new BulletList object with the specified style.
+
+            .DESCRIPTION
+                Creates a new BulletList object with the specified style. An instance of this class
+                is used to render items in a Markdown bullet list, handling indentation and bullet
+                style.
+
+                Use this constructor when creating a top-level list. The style of the list is used
+                to determine the bullet style for the text.
+
+            .PARAMETER Style
+                The style of the bullet list. Valid styles include:
+
+                  - `Hyphen`
+                  - `Plus`
+                  - `Asterisk`
+
+                The default style is `Hyphen`.
+        #>
+
+        $this.Initialize(@{ Style = $Style })
+    }
+
+    BulletList([string[]]$items, [BulletListStyle]$Style) {
+        <#
+            .SYNOPSIS
+                Creates a new BulletList object with the specified items and style.
+
+            .DESCRIPTION
+                Creates a new BulletList object with the specified items and style. An instance of
+                this class is used to render items in a Markdown bullet list, handling indentation
+                and bullet style.
+
+                Use this constructor when creating a top-level list. The style of the list is used
+                to determine the bullet style for the text.
+
+            .PARAMETER items
+                The items to add to the bullet list.
+
+            .PARAMETER Style
+                The style of the bullet list. Valid styles include:
+
+                  - `Hyphen`
+                  - `Plus`
+                  - `Asterisk`
+
+                The default style is `Hyphen`.
+        #>
+
+        $this.Initialize(@{
+                Items = $items
+                Style = $Style
+            })
+    }
+
+    [string] GetPrefix() {
+        <#
+            .SYNOPSIS
+                Gets the prefix for the bullet list.
+
+            .DESCRIPTION
+                Gets the prefix for the bullet list. The prefix is the string that is used to
+                insert the bullet style and indentation level of the list for the first line of
+                a list item in Markdown.
+
+            .EXAMPLE
+                ```powershell
+                $list   = [BulletList]::new(2, [BulletListStyle]::Plus)
+                $prefix = $list.GetPrefix()
+                "'$prefix'"
+                ```
+
+                ```output
+                '  + '
+                ```
+
+            .OUTPUTS
+                [string]
+                    The prefix for the bullet list.
+        #>
+
+        $prefix = switch ($this.Style) {
+            Hyphen   { '- ' }
+            Plus     { '+ ' }
+            Asterisk { '* ' }
+        }
+
+        return $prefix
+    }
+
+    [string[]] FormatListItem([string]$content) {
+        <#
+            .SYNOPSIS
+                Formats the specified content as a bullet list item.
+
+            .DESCRIPTION
+                Formats the specified content as a bullet list item. The content is indented and
+                prefixed with the appropriate bullet style.
+
+            .EXAMPLE
+                $list = [BulletList]::new(2, [BulletListStyle]::Plus)
+                $list.FormatListItem("This is a list item.")
+                # Output: "    + This is a list item."
+
+            .PARAMETER content
+                The content to format as a bullet list item.
+
+            .OUTPUTS
+                [string[]]
+                    The formatted bullet list item.
+        #>
+
+        $prefix = $this.GetPrefix()
+
+        return [MarkdownList]::FormatListItem($content, $prefix)
+    }
+
+    [string[]] FormatListItem([int]$index) {
+        <#
+            .SYNOPSIS
+                Formats the specified index as a bullet list item.
+
+            .DESCRIPTION
+                Formats the specified index as a bullet list item. The index is indented and
+                prefixed with the appropriate bullet style.
+
+            .EXAMPLE
+                $list = [BulletList]::new(2, [BulletListStyle]::Plus)
+                $list.FormatListItem(1)
+                # Output: "    + 1."
+
+            .PARAMETER index
+                The index to format as a bullet list item.
+
+            .OUTPUTS
+                [string[]]
+                    The formatted bullet list item.
+        #>
+
+        $listItem = $this.Items[$index]
+
+        if ([string]::IsNullOrEmpty($listItem)) {
+            $Message = @(
+                "The list item at index $index is null or empty,"
+                'or no entry at that index exists.'
+            ) -join ' '
+
+            throw [ArgumentNullException]::new($Message)
+        }
+
+        return $this.FormatListItem($listItem)
+    }
+
+    [string[]] FormatList() {
+        <#
+            .SYNOPSIS
+                Formats the list items as a bullet list.
+
+            .DESCRIPTION
+                Formats the list items as a bullet list. Each item is indented and prefixed with
+                the appropriate bullet style.
+
+            .EXAMPLE
+                $list = [BulletList]::new(2, [BulletListStyle]::Plus)
+                $list.Items = @("Item 1", "Item 2", "Item 3")
+                $list.FormatList()
+                # Output:
+                #     + Item 1
+                #     + Item 2
+                #     + Item 3
+
+            .OUTPUTS
+                [string[]]
+                    The formatted bullet list.
+        #>
+
+        [string[]]$listLines = @()
+
+        foreach ($item in $this.Items) {
+            $listLines += $this.FormatListItem($item)
+        }
+
+        return $listLines
+    }
+
+    static [string[]] FormatList([string[]]$items) {
+        <#
+            .SYNOPSIS
+                Formats the specified items as a bullet list.
+            .DESCRIPTION
+                Formats the specified items as a bullet list. Each item is indented and prefixed
+                with the default bullet style and a depth of one.
+        #>
+
+        return [BulletList]::new($items).FormatList()
+    }
+
+    static [string[]] FormatList([string[]]$items, [BulletListStyle]$style) {
+        <#
+            .SYNOPSIS
+                Formats the specified items as a bullet list.
+            .DESCRIPTION
+                Formats the specified items as a bullet list. Each item is indented and prefixed
+                with the specified bullet style and a depth of one.
+        #>
+
+        return [BulletList]::new($items, $style).FormatList()
+    }
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/InlineFormatter.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/InlineFormatter.psm1
@@ -1,0 +1,205 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+class InlineFormatter {
+    # The line ending character flags, any combination of `CR` and `LF`.
+    [EmphasisStyle]
+    $EmphasisStyle = [EmphasisStyle]::Underscore
+
+    [EmphasisStyle]
+    $StrongStyle = [EmphasisStyle]::Asterisk
+
+    [StrikethroughStyle]
+    $StrikethroughStyle = [StrikethroughStyle]::Tilde
+
+    [HighlightStyle]
+    $HighlightStyle = [HighlightStyle]::HTML
+
+    [SubscriptStyle]
+    $SubscriptStyle = [SubscriptStyle]::HTML
+
+    [SuperscriptStyle]
+    $SuperscriptStyle = [SuperscriptStyle]::HTML
+
+
+    [string] Emphasize([string] $text) {
+        <#
+            .SYNOPSIS
+            Emphasizes the specified text.
+
+            .DESCRIPTION
+            Emphasizes the specified text.
+
+            .PARAMETER Text
+            The text to emphasize.
+        #>
+
+        $munged = switch ($this.EmphasisStyle) {
+            Underscore { "_${text}_" }
+            Asterisk   { "*${text}*" }
+            HTML       { "<em>${text}</em>" }
+        }
+
+        return $munged
+    }
+
+    [string] StronglyEmphasize([string] $text) {
+        <#
+            .SYNOPSIS
+            Strongly emphasizes the specified text.
+
+            .DESCRIPTION
+            Strongly emphasizes the specified text.
+
+            .PARAMETER Text
+            The text to strongly emphasize.
+        #>
+
+        $munged = switch ($this.StrongStyle) {
+            Underscore { "__${text}__" }
+            Asterisk   { "**${text}**" }
+            HTML       { "<strong>${text}</strong>" }
+        }
+
+        return $munged
+    }
+
+    [string] InlineCode([string] $text) {
+        <#
+            .SYNOPSIS
+            Formats the specified text as inline code.
+
+            .DESCRIPTION
+            Formats the specified text as inline code.
+
+            .PARAMETER Text
+            The text to format as inline code.
+        #>
+
+        $munged = $text
+
+        if ($text -match '`+') {
+            $MinimumCount = $text |
+                Select-String -AllMatches -Pattern '(?m)(?<InnerBackTick>`+)' |
+                Select-Object -ExpandProperty Matches |
+                ForEach-Object { $_.Groups.Where{$_.Name -eq 'InnerBacktick'}.Length } |
+                Sort-Object -Descending |
+                Select-Object -First 1
+
+            $wrapper = '`' * ($MinimumCount + 1)
+            $munged  = "${wrapper}${text}${wrapper}"
+        } else {
+            $munged = "``${text}``"
+        }
+
+        return $munged
+    }
+
+    [string] Strikethrough([string] $text) {
+        <#
+            .SYNOPSIS
+            Formats the specified text as strikethrough text.
+
+            .DESCRIPTION
+            Formats the specified text as strikethrough text.
+
+            .PARAMETER Text
+            The text to format as strikethrough text.
+        #>
+
+        $munged = switch ($this.StrikethroughStyle) {
+            Tilde { "~~${text}~~" }
+            HTML  { "<del>${text}</del>" }
+        }
+
+        return $munged
+    }
+
+    [string] Highlight([string] $text) {
+        <#
+            .SYNOPSIS
+            Formats the specified text as highlighted text.
+
+            .DESCRIPTION
+            Formats the specified text as highlighted text.
+
+            .PARAMETER Text
+            The text to format as highlighted text.
+        #>
+
+        $munged = switch ($this.HighlightStyle) {
+            HTML    { "<mark>${text}</mark>" }
+            Equals  { "==${text}==" }
+        }
+
+        return $munged
+    }
+
+    [string] Superscript([string] $text) {
+        <#
+            .SYNOPSIS
+            Formats the specified text as superscript text.
+
+            .DESCRIPTION
+            Formats the specified text as superscript text.
+
+            .PARAMETER Text
+            The text to format as superscript text.
+        #>
+
+        $munged = switch ($this.SuperscriptStyle) {
+            HTML  { "<sup>${text}</sup>" }
+            Caret { "^${text}^" }
+        }
+
+        return $munged
+    }
+
+    [string] Subscript([string] $text) {
+        <#
+            .SYNOPSIS
+            Formats the specified text as subscript text.
+
+            .DESCRIPTION
+            Formats the specified text as subscript text.
+
+            .PARAMETER Text
+            The text to format as subscript text.
+        #>
+
+        $munged = switch ($this.SubscriptStyle) {
+            HTML  { "<sub>${text}</sub>" }
+            Tilde { "~${text}~" }
+        }
+
+        return $munged
+    }
+
+    [string] Format([string] $text, [InlineFormatOptions]$options) {
+        $munged = $text
+
+        if ($options.HasFlag([InlineFormatOptions]::Code)) {
+            $munged = $this.InlineCode($munged)
+        }
+        if ($options.HasFlag([InlineFormatOptions]::Emphasize)) {
+            $munged = $this.Emphasize($munged)
+        }
+        if ($options.HasFlag([InlineFormatOptions]::Strong)) {
+            $munged = $this.StronglyEmphasize($munged)
+        }
+        if ($options.HasFlag([InlineFormatOptions]::Strikethrough)) {
+            $munged = $this.Strikethrough($munged)
+        }
+        if ($options.HasFlag([InlineFormatOptions]::Highlight)) {
+            $munged = $this.Highlight($munged)
+        }
+        if ($options.HasFlag([InlineFormatOptions]::Superscript)) {
+            $munged = $this.Superscript($munged)
+        }
+        if ($options.HasFlag([InlineFormatOptions]::Subscript)) {
+            $munged = $this.Subscript($munged)
+        }
+
+        return $munged
+    }
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/MarkdownBuilder.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/MarkdownBuilder.psm1
@@ -1,8 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+using module ../Enums/BulletListStyle.psm1
+using module ../Enums/NumberedListStyle.psm1
+using module ../Enums/SpaceMungingOptions.psm1
 using module ./CodeFenceCharacter.psm1
 using module ./LineEnding.psm1
+using module ./MarkdownList.psm1
+using module ./BulletList.psm1
+using module ./NumberedList.psm1
+using module ./InlineFormatter.psm1
 
 class MarkdownBuilder {
     # The StringBuilder this class wraps for building Markdown content.
@@ -17,14 +24,45 @@ class MarkdownBuilder {
     [CodeFenceCharacter]
     $DefaultFenceCharacter
 
-    # The default length of code fences.
+    # The default length of code fences. Nested fences are automatically updated to ensure they
+    # increase the number of characters by this amount. Users can override this value on a
+    # per-fence basis.
     [ValidateRange(3, [int]::MaxValue)]
     [int]
     $DefaultFenceLength = 3
 
+    # The default style to use for numbered lists. This can be overridden on a per-list basis.
+    [NumberedListStyle]
+    $NumberedListStyle = [NumberedListStyle]::SameNumberPeriod
+
+    # The default style to use for bullet lists. This can be overridden on a per-list basis.
+    [BulletListStyle]
+    $BulletListStyle = [BulletListStyle]::Hyphen
+
+    # A collection of open bullet lists.
+    [System.Collections.Generic.List[BulletList]]
+    $BulletLists
+
+    # A collection of open bullet lists.
+    [System.Collections.Generic.List[MarkdownList]]
+    $Lists
+
+    # The custom formatting to apply to inline elements.
+    [InlineFormatter]
+    $InlineFormatter
+
     # The default line ending to use when appending lines.
     [LineEnding]
     $DefaultLineEnding
+
+    # The default options for space munging. By default, the MarkdownBuilder doesn't munge any
+    # spaces and passes the text back exactly as submitted.
+    [SpaceMungingOptions]
+    $SpaceMungingOptions = [SpaceMungingOptions]::None
+
+    [ValidateRange(0, [int]::MaxValue)]
+    [int]
+    $LeadingSpaceCount = 0
 
     MarkdownBuilder() {
         <#
@@ -35,10 +73,7 @@ class MarkdownBuilder {
             default options.
         #>
 
-        $this.StringBuilder = [System.Text.StringBuilder]::new()
-        $this.Fences = [System.Collections.Generic.Dictionary[int, string]]::new()
-        $this.DefaultLineEnding = [LineEnding]::new()
-        $this.DefaultFenceCharacter = [CodeFenceCharacter]::new()
+        $this.InitializeDefaultProperties()
     }
 
     MarkdownBuilder([LineEnding]$defaultLineEnding) {
@@ -50,10 +85,27 @@ class MarkdownBuilder {
             specified default line ending. All other options are default.
         #>
 
-        $this.StringBuilder = [System.Text.StringBuilder]::new()
-        $this.Fences = [System.Collections.Generic.Dictionary[int, string]]::new()
+        $this.InitializeDefaultProperties()
+
         $this.DefaultLineEnding = $defaultLineEnding
-        $this.DefaultFenceCharacter = [CodeFenceCharacter]::new()
+    }
+
+    MarkdownBuilder(
+        [LineEnding]$defaultLineEnding,
+        [SpaceMungingOptions]$spaceMungingOptions
+    ) {
+        <#
+            .SYNOPSIS
+            Creates a new MarkdownBuilder object.
+            .DESCRIPTION
+            Creates a new MarkdownBuilder object with an empty StringBuilder and
+            specified default line ending. All other options are default.
+        #>
+
+        $this.InitializeDefaultProperties()
+
+        $this.DefaultLineEnding     = $defaultLineEnding
+        $this.SpaceMungingOptions   = $spaceMungingOptions
     }
 
     MarkdownBuilder([string]$content) {
@@ -66,10 +118,9 @@ class MarkdownBuilder {
             default options.
         #>
 
+        $this.InitializeDefaultProperties()
+
         $this.StringBuilder = [System.Text.StringBuilder]::new($content)
-        $this.Fences = [System.Collections.Generic.Dictionary[int, string]]::new()
-        $this.DefaultLineEnding = [LineEnding]::new()
-        $this.DefaultFenceCharacter = [CodeFenceCharacter]::new()
     }
 
     MarkdownBuilder([System.Text.StringBuilder]$builder) {
@@ -82,10 +133,9 @@ class MarkdownBuilder {
             and with default options.
         #>
 
+        $this.InitializeDefaultProperties()
+
         $this.StringBuilder = $builder
-        $this.Fences = [System.Collections.Generic.Dictionary[int, string]]::new()
-        $this.DefaultLineEnding = [LineEnding]::new()
-        $this.DefaultFenceCharacter = [CodeFenceCharacter]::new()
     }
 
     MarkdownBuilder([string]$content, [LineEnding]$defaultLineEnding) {
@@ -97,10 +147,10 @@ class MarkdownBuilder {
             default line ending. All other options are default.
         #>
 
-        $this.StringBuilder = [System.Text.StringBuilder]::new($content)
-        $this.Fences = [System.Collections.Generic.Dictionary[int, string]]::new()
+        $this.InitializeDefaultProperties()
+
+        $this.StringBuilder     = [System.Text.StringBuilder]::new($content)
         $this.DefaultLineEnding = $defaultLineEnding
-        $this.DefaultFenceCharacter = [CodeFenceCharacter]::new()
     }
 
     MarkdownBuilder([System.Text.StringBuilder]$builder, [LineEnding]$defaultLineEnding) {
@@ -112,10 +162,33 @@ class MarkdownBuilder {
             builder and default line ending. All other options are default.
         #>
 
-        $this.StringBuilder = $builder
-        $this.Fences = [System.Collections.Generic.Dictionary[int, string]]::new()
+        $this.InitializeDefaultProperties()
+
+        $this.StringBuilder     = $builder
         $this.DefaultLineEnding = $defaultLineEnding
+    }
+
+    hidden [void] InitializeDefaultProperties() {
+        <#
+            .SYNOPSIS
+            Initializes the default properties of the MarkdownBuilder object.
+
+            .DESCRIPTION
+            Initializes the default properties of the MarkdownBuilder object.
+            This method is used by the MarkdownBuilder constructors to ensure
+            the object has the correct default properties.
+
+            Constructors should call this method before setting the properties
+            based on the method parameters, so the user-specified values override
+            the default values.
+        #>
+
+        $this.StringBuilder         = [System.Text.StringBuilder]::new()
         $this.DefaultFenceCharacter = [CodeFenceCharacter]::new()
+        $this.DefaultLineEnding     = [LineEnding]::new()
+        $this.Fences                = [System.Collections.Generic.Dictionary[int, string]]::new()
+        $this.Lists                 = [System.Collections.Generic.List[MarkdownList]]::new()
+        $this.InlineFormatter       = [InlineFormatter]::new()
     }
 
     hidden [void] ReplaceCodeFence([int]$Index, [string]$OldFence, [string]$NewFence) {
@@ -358,6 +431,614 @@ class MarkdownBuilder {
         return $this
     }
 
+    [MarkdownBuilder] AppendCodeBlock([string]$code) {
+        <#
+            .SYNOPSIS
+            Appends a code block to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a code block to the MarkdownBuilder. The code block is
+            wrapped in a code fence with the default options and no language ID.
+
+            .PARAMETER code
+            The code to append to the MarkdownBuilder.
+        #>
+
+        return $this.AppendCodeBlock($code, $this.DefaultLineEnding)
+    }
+
+    [MarkdownBuilder] AppendCodeBlock([string]$code, [string]$language) {
+        <#
+            .SYNOPSIS
+            Appends a code block to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a code block to the MarkdownBuilder. The code block is
+            wrapped in a code fence with the specified language ID.
+
+            .PARAMETER code
+            The code to append to the MarkdownBuilder.
+
+            .PARAMETER language
+            The language ID to use for the code fence. This can be any string,
+            but your Markdown parser or syntax highlighter might only support
+            specific language IDs.
+        #>
+
+        return $this.AppendCodeBlock($code, $language, $this.DefaultLineEnding)
+    }
+
+    [MarkdownBuilder] AppendCodeBlock([string]$code, [LineEnding]$lineEnding) {
+        <#
+            .SYNOPSIS
+            Appends a code block to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a code block to the MarkdownBuilder. The code block is
+            wrapped in a code fence with the default options and no language ID.
+
+            .PARAMETER code
+            The code to append to the MarkdownBuilder.
+
+            .PARAMETER lineEnding
+            The line ending to use for the code fence. Valid options include:
+
+            - `[LineEnding]::CR` - `\r`
+            - `[LineEnding]::CRLF` - `\r\n`
+            - `[LineEnding]::LF` - `\n`
+        #>
+
+        return $this.AppendCodeBlock($code, '', $lineEnding)
+    }
+
+    [MarkdownBuilder] AppendCodeBlock([string]$code, [string]$language, [LineEnding]$lineEnding) {
+        <#
+            .SYNOPSIS
+            Appends a code block to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a code block to the MarkdownBuilder. The code block is
+            wrapped in a code fence with the specified language ID.
+
+            .PARAMETER code
+            The code to append to the MarkdownBuilder.
+
+            .PARAMETER language
+            The language ID to use for the code fence. This can be any string,
+            but your Markdown parser or syntax highlighter might only support
+            specific language IDs.
+
+            .PARAMETER lineEnding
+            The line ending to use for the code fence. Valid options include:
+
+            - `[LineEnding]::CR` - `\r`
+            - `[LineEnding]::CRLF` - `\r\n`
+            - `[LineEnding]::LF` - `\n`
+        #>
+
+        $this.OpenCodeFence(
+            $language,
+            $this.DefaultFenceCharacter,
+            $this.DefaultFenceLength,
+            $lineEnding
+        )
+        $this.AppendLine($code, $lineEnding)
+        $this.CloseCodeFence($lineEnding)
+
+        return $this
+    }
+
+    [MarkdownBuilder] AppendCodeBlock(
+        [string]$code,
+        [string]$language,
+        [CodeFenceCharacter]$fenceCharacter,
+        [int]$fenceLength,
+        [LineEnding]$lineEnding
+    ) {
+        $this.OpenCodeFence(
+            $language,
+            $fenceCharacter,
+            $fenceLength,
+            $lineEnding
+        ).AppendLine(
+            $code,
+            $lineEnding
+        ).CloseCodeFence($lineEnding)
+
+        return $this
+    }
+
+    [MarkdownBuilder] StartBulletList() {
+        <#
+            .SYNOPSIS
+            Starts a bullet list with the default bullet style.
+
+            .DESCRIPTION
+            Starts a bullet list with the default bullet style. If there's already a list open,
+            this method opens a nested list. #>
+
+        return $this.StartBulletList($this.BulletListStyle)
+    }
+
+    [MarkdownBuilder] StartBulletList([BulletListStyle]$bulletListStyle) {
+        <#
+            .SYNOPSIS
+            Starts a bullet list with the specified bullet style.
+
+            .DESCRIPTION
+            Starts a bullet list with the specified bullet style. If there's already a list open,
+            this method does opens a nested list.
+
+            .PARAMETER bulletListStyle
+            The bullet style to use for the bullet list. Valid options include:
+
+            - `[BulletListStyle]::Asterisk` - `*`
+            - `[BulletListStyle]::Hyphen` - `-`
+            - `[BulletListStyle]::Plus` - `+`
+        #>
+
+        $bulletList = [BulletList]::new($bulletListStyle)
+        $this.Lists.Add($bulletList)
+
+        return $this
+    }
+
+    [MarkdownBuilder] StartNumberedList() {
+        <#
+            .SYNOPSIS
+            Starts a numbered list with the default style.
+
+            .DESCRIPTION
+            Starts a numbered list with the default style. If there's already a list open, this
+            method opens a nested list. #>
+
+        return $this.StartNumberedList($this.NumberedListStyle)
+    }
+
+    [MarkdownBuilder] StartNumberedList([NumberedListStyle]$style) {
+        <#
+            .SYNOPSIS
+            Starts a numbered list with the specified style.
+
+            .DESCRIPTION
+            Starts a numbered list with the specified style. If there's already a list open, this
+            method opens a nested list.
+
+            .PARAMETER style
+            The style to use for the numbered list. Valid options include:
+
+            - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+              **StartingIndex** for each item, followed by a period. For example, `1.` or `8.`.
+            - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+              **StartingIndex** for each item, followed by a closing parenthesis. For example,
+              `1)` or `8)`.
+            - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+              used for each item in the list, starting with the value of **StartingIndex**. For
+              example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+              numeral counts, this style left-pads the shorter numerals with spaces to align
+              the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+              numeral used for each item in the list, starting with the value of
+              **StartingIndex**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with spaces to align the closing parenthesis.
+            - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+              the numeral used for each item in the list, starting with the value of
+              **StartingIndex**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+              increments the numeral used for each item in the list, starting with the value of
+              **StartingIndex**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing parenthesis.
+        #>
+
+        $numberedList = [NumberedList]::new($style)
+        $this.Lists.Add($numberedList)
+
+        return $this
+    }
+
+    [MarkdownBuilder] StartNumberedList([int]$startingNumber) {
+        <#
+            .SYNOPSIS
+            Starts a numbered list with the default style and the specified starting number.
+
+            .DESCRIPTION
+            Starts a numbered list with the default style and the specified starting number. If
+            there's already a list open, this method opens a nested list.
+
+            .PARAMETER startingNumber
+            The number to start the list at. This value is used to determine the number to start
+            the list at, enabling lists to start at a number other than `1`.
+        #>
+
+        return $this.StartNumberedList($this.NumberedListStyle, $startingNumber)
+    }
+
+    [MarkdownBuilder] StartNumberedList([NumberedListStyle]$style, [int]$startingNumber) {
+        <#
+            .SYNOPSIS
+            Starts a numbered list with the specified style and starting number.
+
+            .DESCRIPTION
+            Starts a numbered list with the specified style and starting number. If there's
+            already a list open, this method opens a nested list.
+
+            .PARAMETER style
+            The style to use for the numbered list. Valid options include:
+
+            - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+              **StartingIndex** for each item, followed by a period. For example, `1.` or `8.`.
+            - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+              **StartingIndex** for each item, followed by a closing parenthesis. For example,
+              `1)` or `8)`.
+            - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+              used for each item in the list, starting with the value of **StartingIndex**. For
+              example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+              numeral counts, this style left-pads the shorter numerals with spaces to align
+              the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+              numeral used for each item in the list, starting with the value of
+              **StartingIndex**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with spaces to align the closing parenthesis.
+            - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+              the numeral used for each item in the list, starting with the value of
+              **StartingIndex**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+              increments the numeral used for each item in the list, starting with the value of
+              **StartingIndex**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing parenthesis.
+
+            .PARAMETER startingNumber
+            The number to start the list at. This value is used to determine the number to start
+            the list at, enabling lists to start at a number other than `1`.
+        #>
+
+        $numberedList = [NumberedList]::new($startingNumber, $style)
+        $this.Lists.Add($numberedList)
+
+        return $this
+    }
+
+    [MarkdownBuilder] AddListItem([string]$item) {
+        <#
+            .SYNOPSIS
+            Adds an item to the current list.
+
+            .DESCRIPTION
+
+            Adds an item to the current list. If there's no list open, this method
+            throws an error. The item is added to the _last_ opened list. If you have nested
+            lists, you can use this method to add items to the innermost list.
+
+            To add an item to a specific list, use the `AddItem` method on the list,
+            or use the `AddListItem()` method with the specified index.
+
+            .PARAMETER item
+            The item to add to the list.
+        #>
+
+        return $this.AddListItem(($this.Lists.Count - 1), $item)
+    }
+
+    [MarkdownBuilder] AddListItem([int]$index, [string]$item) {
+        <#
+            .SYNOPSIS
+            Adds an item to the specified list.
+
+            .DESCRIPTION
+            Adds an item to the specified list. If there's no list open, this method
+            throws an error. The item is added to the _last_ opened list. If you have nested
+         lists, you can use this method to add items to the innermost list.
+
+            To add an item to a specific list, use the `AddItem` method on the list,
+            or use the `AdListItem()` method with the specified index.
+
+            .PARAMETER index
+            The index of the list to add the item to.
+
+            .PARAMETER item
+            The item to add to the list.
+        #>
+
+        if ($this.Lists.Count -eq 0) {
+            throw [System.InvalidOperationException]::new('There is no open list.')
+        }
+
+        if ($index -lt 0 -or $index -ge $this.Lists.Count) {
+            throw [System.ArgumentOutOfRangeException]::new(
+                'index',
+                $index,
+                'The index must be greater than or equal to 0 and less than the number of open lists.'
+            )
+        }
+
+        $this.Lists[$index].Items += $item
+
+        return $this
+    }
+
+    [MarkdownBuilder] EndList() {
+        <#
+            .SYNOPSIS
+            Ends the most recently opened list.
+
+            .DESCRIPTION
+            Ends the most recently opened list. If there are no open lists, this method throws an
+            error. If there are nested lists, the innermost list is formatted and appended to the
+            next outer list as a single item. If there is only one list open, the list is formatted
+            and appended to the prose.
+
+            This overload uses the default line ending for the builder.
+        #>
+
+        return $this.EndList($this.DefaultLineEnding)
+    }
+
+    [MarkdownBuilder] EndList([LineEnding]$lineEnding) {
+        <#
+            .SYNOPSIS
+            Ends the most recently opened list.
+
+            .DESCRIPTION
+            Ends the most recently opened list. If there are no open lists, this method throws an
+            error. If there are nested lists, the innermost list is formatted and appended to the
+            next outer list as a single item. If there is only one list open, the list is formatted
+            and appended to the prose.
+
+            .PARAMETER lineEnding
+            The line ending to use when formatting the list. Valid options include:
+
+            - `[LineEnding]::CR` - `\r`
+            - `[LineEnding]::CRLF` - `\r\n`
+            - `[LineEnding]::LF` - `\n`
+        #>
+
+        $lineEnding = $lineEnding.ToString()
+
+        if ($this.Lists.Count -eq 0) {
+            throw [System.InvalidOperationException]::new('There is no open list.')
+        } elseif ($this.Lists.Count -gt 1) {
+            $listIndex  = $this.Lists.Count - 1
+            $endingList = $this.Lists[$listIndex]
+            $formatted  = $endingList.FormatList() -join $lineEnding
+
+            $this.Lists[-2].Items += $formatted
+
+            $this.Lists.RemoveAt($listIndex)
+        } else {
+            $listLines = $this.Lists[0].FormatList()
+
+            $this.AppendLine($listLines, $lineEnding)
+            $this.AppendLine($lineEnding)
+        }
+
+        return $this
+    }
+
+    [MarkdownBuilder] AppendList([MarkdownList]$list) {
+        <#
+            .SYNOPSIS
+            Appends a list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings.
+
+            .PARAMETER list
+            The bullet list to append to the MarkdownBuilder.
+        #>
+
+        return $this.AppendList($list, $this.DefaultLineEnding)
+    }
+
+    [MarkdownBuilder] AppendList([MarkdownList]$list, [LineEnding]$lineEnding) {
+        <#
+            .SYNOPSIS
+            Appends a bullet list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a bullet list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings and the specified line ending.
+
+            .PARAMETER list
+            The bullet list to append to the MarkdownBuilder.
+
+            .PARAMETER lineEnding
+            The line ending to use when formatting the bullet list. Valid options include:
+
+            - `[LineEnding]::CR` - `\r`
+            - `[LineEnding]::CRLF` - `\r\n`
+            - `[LineEnding]::LF` - `\n`
+        #>
+
+        $listLines = $list.FormatList()
+
+        foreach ($line in $listLines) {
+            $this.AppendLine($line, $lineEnding)
+        }
+
+        return $this
+    }
+    [MarkdownBuilder] AppendBulletList([BulletList]$list) {
+        <#
+            .SYNOPSIS
+            Appends a bullet list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a bullet list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings.
+
+            .PARAMETER list
+            The bullet list to append to the MarkdownBuilder.
+        #>
+
+        return $this.AppendBulletList($list, $this.DefaultLineEnding)
+    }
+
+    [MarkdownBuilder] AppendBulletList([BulletList]$list, [LineEnding]$lineEnding) {
+        <#
+            .SYNOPSIS
+            Appends a bullet list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a bullet list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings and the specified line ending.
+
+            .PARAMETER list
+            The bullet list to append to the MarkdownBuilder.
+
+            .PARAMETER lineEnding
+            The line ending to use when formatting the bullet list. Valid options include:
+
+            - `[LineEnding]::CR` - `\r`
+            - `[LineEnding]::CRLF` - `\r\n`
+            - `[LineEnding]::LF` - `\n`
+        #>
+
+        $listLines = $list.FormatList()
+
+        foreach ($line in $listLines) {
+            $this.AppendLine($line, $lineEnding)
+        }
+
+        return $this
+    }
+
+    [MarkdownBuilder] AppendBulletList([string[]]$items) {
+        <#
+            .SYNOPSIS
+            Appends a bullet list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a bullet list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings
+
+            .PARAMETER items
+            The items to add to the bullet list.
+        #>
+
+        $list = [BulletList]::new($items, $this.BulletListStyle)
+
+        return $this.AppendBulletList($list)
+    }
+
+    [MarkdownBuilder] AppendBulletList([string[]]$items, [LineEnding]$lineEnding) {
+        <#
+            .SYNOPSIS
+            Appends a bullet list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a bullet list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings
+
+            .PARAMETER items
+            The items to add to the bullet list.
+
+            .PARAMETER lineEnding
+            The line ending to use when formatting the bullet list. Valid options include:
+
+            - `[LineEnding]::CR` - `\r`
+            - `[LineEnding]::CRLF` - `\r\n`
+            - `[LineEnding]::LF` - `\n`
+        #>
+
+        $list = [BulletList]::new($items, $this.BulletListStyle)
+
+        return $this.AppendBulletList($list, $lineEnding)
+    }
+
+    [MarkdownBuilder] AppendBulletList([string[]]$items, [BulletListStyle]$bulletListStyle) {
+        <#
+            .SYNOPSIS
+            Appends a bullet list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a bullet list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings
+
+            .PARAMETER items
+            The items to add to the bullet list.
+
+            .PARAMETER bulletListStyle
+            The bullet style to use for the bullet list. Valid options include:
+
+            - `[BulletListStyle]::Asterisk` - `*`
+            - `[BulletListStyle]::Hyphen` - `-`
+            - `[BulletListStyle]::Plus` - `+`
+        #>
+
+        $list = [BulletList]::new($items, $bulletListStyle)
+
+        return $this.AppendBulletList($list)
+    }
+
+    [MarkdownBuilder] AppendBulletList(
+        [string[]]$items,
+        [BulletListStyle]$bulletListStyle,
+        [LineEnding]$lineEnding
+    ) {
+        <#
+            .SYNOPSIS
+            Appends a bullet list to the MarkdownBuilder.
+
+            .DESCRIPTION
+            Appends a bullet list to the MarkdownBuilder. The list is formatted
+            and then inserted into the prose, using the current indentation and
+            other settings
+
+            .PARAMETER items
+            The items to add to the bullet list.
+
+            .PARAMETER bulletListStyle
+            The bullet style to use for the bullet list. Valid options include:
+
+            - `[BulletListStyle]::Asterisk` - `*`
+            - `[BulletListStyle]::Hyphen` - `-`
+            - `[BulletListStyle]::Plus` - `+`
+
+            .PARAMETER lineEnding
+            The line ending to use when formatting the bullet list. Valid options include:
+
+            - `[LineEnding]::CR` - `\r`
+            - `[LineEnding]::CRLF` - `\r\n`
+            - `[LineEnding]::LF` - `\n`
+        #>
+
+        $list = [BulletList]::new($items, $bulletListStyle)
+
+        return $this.AppendBulletList($list, $lineEnding)
+    }
+
+    [MarkdownBuilder] Append([string]$Content) {
+        <#
+            .SYNOPSIS
+            Appends the specified content to the wrapped StringBuilder.
+
+            .DESCRIPTION
+            Appends the specified content to the wrapped StringBuilder. This
+            provides a convenient way to append content without having to call
+            the Append method on the StringBuilder directly.
+        #>
+
+        $this.StringBuilder.Append($Content)
+
+        return $this
+    }
+
     [MarkdownBuilder] AppendLine() {
         <#
             .SYNOPSIS
@@ -398,6 +1079,22 @@ class MarkdownBuilder {
             the AppendLine method on the StringBuilder directly.
         #>
 
+        $lineContent = (' ' * $this.LeadingSpaceCount) + $Content
+
+        return $this.AppendLine($lineContent, $this.DefaultLineEnding)
+    }
+
+    [MarkdownBuilder] AppendLine([string[]]$Content) {
+        <#
+            .SYNOPSIS
+            Appends a new line with the specified content to the wrapped StringBuilder.
+
+            .DESCRIPTION
+            Appends a new line with the specified content to the wrapped StringBuilder.
+            This provides a convenient way to append a new line without having to call
+            the AppendLine method on the StringBuilder directly.
+        #>
+
         return $this.AppendLine($Content, $this.DefaultLineEnding)
     }
 
@@ -411,7 +1108,29 @@ class MarkdownBuilder {
             This provides a convenient way to append a new line without having to call
             the AppendLine method on the StringBuilder directly.
         #>
-        $this.StringBuilder.Append($Content).Append($LineEnding.ToString())
+
+        foreach ($line in ([MarkdownBuilder]::SplitLines($Content))) {
+            $lineContent = (' ' * $this.LeadingSpaceCount) + $line
+            $this.StringBuilder.Append($lineContent).Append($LineEnding.ToString())
+        }
+
+        return $this
+    }
+
+    [MarkdownBuilder] AppendLine([string[]]$Content, [LineEnding]$LineEnding) {
+        <#
+            .SYNOPSIS
+            Appends a new line with the specified content to the wrapped StringBuilder.
+
+            .DESCRIPTION
+            Appends a new line with the specified content to the wrapped StringBuilder.
+            This provides a convenient way to append a new line without having to call
+            the AppendLine method on the StringBuilder directly.
+        #>
+
+        foreach ($block in $content) {
+            $this.AppendLine($block, $LineEnding)
+        }
 
         return $this
     }
@@ -429,6 +1148,34 @@ class MarkdownBuilder {
             It also ensures that when you interpolate the MarkdownBuilder object
             in a string, you get the Markdown content instead of the object type.
         #>
-        return $this.StringBuilder.ToString()
+
+        $output = $this.StringBuilder.ToString()
+
+        switch ($this.SpaceMungingOptions.GetFlags()) {
+            CollapseStart { $output = $output -replace '^(\r?\n)+', '$1' }
+            CollapseEnd { $output = $output -replace '(\r?\n)+$', '$1' }
+            CollapseInner { <# Not yet implemented #> }
+            TrimStart { $output = $Output.TrimStart() }
+            TrimEnd { $output = $Output.TrimEnd() }
+        }
+
+        return $output
+    }
+
+    static [string[]] SplitLines([string]$content) {
+        <#
+            .SYNOPSIS
+            Splits a string into an array of lines.
+
+            .DESCRIPTION
+            Splits a string into an array of lines. This method is used to
+            split a string into lines so that you can iterate over them and
+            process them individually.
+
+            .PARAMETER content
+            The string to split into lines.
+        #>
+
+        return (($content -split '\r?\n') -split '\r')
     }
 }

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/MarkdownList.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/MarkdownList.psm1
@@ -1,0 +1,160 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+class MarkdownList {
+    <#
+        .SYNOPSIS
+            The base class for Markdown bullet and numbered lists.
+
+        .DESCRIPTION
+            The base class for Markdown bullet and numbered lists. This class is used to render
+            items in a Markdown list, handling indentation and prefix style. Using the base class
+            allows the same code to be used for both bullet and numbered lists and for the
+            **MarkdownBuilder** to support nested lists of either type.
+    #>
+
+    <#
+        .SYNOPSIS
+            The list items for the Markdown list.
+
+        .DESCRIPTION
+            The list items for the Markdown list. Each item should be a block of Markdown prose.
+            When formatted, the prose should have the appropriate prefix for the list type and
+            inserted for the first line and the remaining lines indented to the appropriate
+            column with spaces.
+    #>
+    [string[]] $Items = @()
+
+    [string[]] FormatList() {
+        <#
+            .SYNOPSIS
+                Formats the list items into a Markdown list with prefix and indentation.
+
+            .DESCRIPTION
+                Formats the list items into a Markdown list with prefix and indentation. This
+                method is used by the **MarkdownBuilder** to render the list items into a Markdown
+                list.
+
+                This method is not implemented in the base class and must be implemented by derived
+                classes.
+        #>
+
+        throw "FormatList() is not implemented."
+    }
+
+    <#
+        .SYNOPSIS
+            A regular expression pattern for matching Markdown bullet list syntax.
+
+        .DESCRIPTION
+            A regular expression pattern for matching Markdown bullet list syntax. This pattern
+            matches the following list prefixes:
+
+            - Hyphen (`-`)
+            - Plus (`+`)
+            - Asterisk (`*`)
+
+            The bullet must be the first non-space character on the line and be followed by a
+            space.
+    #>
+    static [string] $BulletPattern = '(?<bulletPrefix>-|\+|\*) '
+
+    <#
+        .SYNOPSIS
+            A regular expression pattern for matching Markdown numbered list syntax.
+
+        .DESCRIPTION
+            A regular expression pattern for matching Markdown numbered list syntax. It matches
+            the following list prefixes:
+
+            - Number followed by a period (`.`)
+            - Number followed by a closing parenthesis (`)`)
+
+            The number must be the first non-space character on the line. The prefix must be
+            followed by a space.
+    #>
+    static [string] $NumeralPrefixPattern = '(?<numeralPrefix>[0-9]+(\.|\))) '
+
+    <#
+        .SYNOPSIS
+            A regular expression pattern for matching nested list items.
+
+        .DESCRIPTION
+            A regular expression pattern for matching nested list items. It matches the following
+            list prefixes:
+
+            - Hyphen (`-`)
+            - Plus (`+`)
+            - Asterisk (`*`)
+            - Number followed by a period (`.`)
+            - Number followed by a closing parenthesis (`)`)
+
+            The prefix may be preceded by any number of spaces.
+
+            This pattern uses the following named capture groups:
+
+            - `nestedLeadingSpace` - The leading space before the list prefix.
+            - `nestedItemPrefix` - The list prefix.
+            - `bulletPrefix` - The prefix for a bullet list item, if found.
+            - `numeralPrefix` - The prefix for a numbered list item, if found.
+            - `nestedContent` - The content of the list item.
+    #>
+    static [string] $NestedListPattern = @(
+        '^(?<nestedLeadingSpace> *)'            # Capture all leading space til the list prefix.
+        '(?<nestedItemPrefix>('                 # Capture the list prefix.
+            [MarkdownList]::BulletPattern
+            '|'
+            [MarkdownList]::NumeralPrefixPattern
+        '))'
+        '(?<nestedContent>.+)$'                 # Capture the content for the rest of the line.
+    ) -join ''
+
+    <#
+        .SYNOPSIS
+            Formats the specified list item.
+
+        .DESCRIPTION
+            Formats the specified list item. This method is used to format the list items for
+            Markdown lists. It handles adding the prefix to the first line of the list item and
+            indenting the rest of the lines to the appropriate column.
+
+        .PARAMETER item
+            The prose of the list item to format.
+
+        .PARAMETER prefix
+            The prefix to use for the list item, like `- ` or `1. `.
+    #>
+    static [string[]] FormatListItem([string]$item, [string]$prefix) {
+        [string[]]$formattedLines = @()
+
+        $leadingSpace = ' ' * $prefix.Length
+        $lines        = ($item -split '\r?\n') -split '\r'
+        $itemIsNested = $false
+
+        for ($lineIndex = 0 ; $lineIndex -lt $lines.Length ; $lineIndex++) {
+            $line         = $lines[$lineIndex]
+
+            if ($lineIndex -eq 0) {
+                $itemIsNested = $line -match [MarkdownList]::NestedListPattern
+                if ($itemIsNested) {
+                    $replacementPattern = '${nestedLeadingSpace}${nestedItemPrefix}${nestedContent}'
+
+                    $line = $line -replace [MarkdownList]::NestedListPattern, $replacementPattern
+                    $line = "${leadingSpace}$line"
+                } else {
+                    $line = "${prefix}$line"
+                }
+            } else {
+                $line = "${leadingSpace}${line}"
+            }
+
+            $formattedLines += $line
+        }
+
+        if ($itemIsNested) {
+            $formattedLines = [string[]]'' + $formattedLines + ''
+        }
+
+        return $formattedLines
+    }
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/NumberedList.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Classes/NumberedList.psm1
@@ -1,0 +1,777 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Enums/NumberedListStyle.psm1
+using module ../Classes/MarkdownList.psm1
+
+class NumberedList : MarkdownList {
+    <#
+        .SYNOPSIS
+            Represents a Markdown numbered list.
+        .DESCRIPTION
+            Represents a Markdown numbered list. This class is used to render items in a Markdown
+            numbered list, handling indentation and numeral style.
+    #>
+
+    <#
+        .SYNOPSIS
+            The default style for newly created NumberedList objects.
+        
+        .DESCRIPTION
+            The default style for newly created NumberedList objects. This property is used to
+            determine the style of a numbered list when you use one of the constructors that
+            doesn't specify a style.
+
+            The default style is `[NumberedListStyle]::SameNumberPeriod`.
+
+            You can change the default style by setting this property to a different style. For
+            example, to change the default style to `[NumberedListStyle]::IncrementingNumberPeriod`,
+            use the following command:
+
+            ```powershell
+            [NumberedList]::DefaultStyle = [NumberedListStyle]::IncrementingNumberPeriod
+            ```
+
+            The available styles are:
+
+            - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+              **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+            - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+              **StartingNumber** for each item, followed by a closing parenthesis. For example,
+              `1)` or `8)`.
+            - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+              used for each item in the list, starting with the value of **StartingNumber**. For
+              example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+              numeral counts, this style left-pads the shorter numerals with spaces to align
+              the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+              numeral used for each item in the list, starting with the value of
+              **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with spaces to align the closing parenthesis.
+            - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+              the numeral used for each item in the list, starting with the value of
+              **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+              increments the numeral used for each item in the list, starting with the value of
+              **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing parenthesis.
+    #>
+    static
+    [NumberedListStyle]
+    $DefaultStyle = [NumberedListStyle]::SameNumberPeriod
+
+    <#
+        .SYNOPSIS
+            The number to start the list at.
+        
+        .DESCRIPTION
+            The number to start the list at. This property is used to determine the number to start
+            the list at when you use one of the constructors that doesn't specify a starting
+            number.
+
+            The default value is 1.
+    #>
+    [int]
+    $StartingNumber = 1
+
+    <#
+        .SYNOPSIS
+            The style of the numbered list.
+        
+        .DESCRIPTION
+            The style to use when formatting the items as a Markdown numbered list. This property
+            defaults to the value of the static **DefaultStyle** property when you create an
+            instance of this class using a constructor that doesn't specify a style.
+
+            The available styles are:
+
+            - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+              **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+            - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+              **StartingNumber** for each item, followed by a closing parenthesis. For example,
+              `1)` or `8)`.
+            - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+              used for each item in the list, starting with the value of **StartingNumber**. For
+              example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+              numeral counts, this style left-pads the shorter numerals with spaces to align
+              the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+              numeral used for each item in the list, starting with the value of
+              **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with spaces to align the closing parenthesis.
+            - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+              the numeral used for each item in the list, starting with the value of
+              **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing period.
+            - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+              increments the numeral used for each item in the list, starting with the value of
+              **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+              that have different numeral counts, this style left-pads the shorter numerals
+              with zeroes to align the closing parenthesis.
+    #>
+    [NumberedListStyle]
+    $Style
+
+    <#
+        .SYNOPSIS
+            The items in the list.
+        
+        .DESCRIPTION
+            The items in the list. This property is used to determine the items to include in the
+            list when formatting it as Markdown. The items are rendered in the order they're
+            specified in this property. Each item in the list must be the Markdown prose to include
+            for that item. The prose can include line breaks and nested Markdown syntax. When the
+            class formats the items, it handles indentation and the numeral prefix for each item.
+
+            The default value is an empty array.
+    #>
+    [string[]]
+    $Items = @()
+
+    hidden Initialize([hashtable]$properties) {
+        <#
+            .SYNOPSIS
+                Initializes the NumberedList object with the specified properties.
+
+            .DESCRIPTION
+                Initializes the NumberedList object with the specified properties. It sets the
+                **Style** property to the default style defined by the static **DefaultStyle**
+                property and the **Items** property to an empty array.
+
+                This method is hidden from the user because it's not intended to be called
+                directly. It's called by the constructors of this class.
+
+            .PARAMETER properties
+                A hashtable containing the properties to set on the object. Valid properties
+                include:
+
+                - `StartingNumber`
+                - `Style`
+                - `Items`
+        #>
+
+        $this.Style = [NumberedList]::DefaultStyle
+        $this.Items = @()
+
+        foreach ($key in $properties.Keys) {
+            $this.$key = $properties[$key]
+        }
+    }
+
+    NumberedList() {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList object with default values.
+
+            .DESCRIPTION
+                Creates a new NumberedList object with default values. An instance of this class is
+                used to render items in a Markdown bullet list, handling indentation and bullet
+                style.
+        #>
+
+        $this.Initialize(@{})
+    }
+
+    NumberedList([string[]]$items) {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList with the specified items.
+
+            .DESCRIPTION
+                Creates a new NumberedList with the specified items. An instance of this class is
+                used to render items in a Markdown numbered list, handling indentation and numeral
+                style.
+
+                When you use this constructor, the list starts at 1 and uses the default style
+                defined as the static **DefaultStyle** property.
+
+            .PARAMETER items
+                The items to include in the list.
+        #>
+
+        $this.Initialize(@{ Items = $items })
+    }
+
+    NumberedList([NumberedListStyle]$style) {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList object with the specified style.
+
+            .DESCRIPTION
+                Creates a new NumberedList object with the specified style. An instance of this class
+                is used to render items in a Markdown numbered list, handling indentation and style
+                style.
+
+                When you use this constructor, the list starts at 1 and uses the specified style.
+
+            .PARAMETER style
+                The style of the numbered list. Valid styles include:
+
+                - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+                  **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+                - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+                  **StartingNumber** for each item, followed by a closing parenthesis. For example,
+                  `1)` or `8)`.
+                - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+                  used for each item in the list, starting with the value of **StartingNumber**. For
+                  example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+                  numeral counts, this style left-pads the shorter numerals with spaces to align
+                  the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+                  numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with spaces to align the closing parenthesis.
+                - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+                  the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+                  increments the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing parenthesis.
+            #>
+
+        $this.Initialize(@{ Style = $style })
+    }
+
+    NumberedList([string[]]$items, [NumberedListStyle]$style) {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList with the specified items and style.
+
+            .DESCRIPTION
+                Creates a new NumberedList with the specified items and style. An instance of this
+                class is used to render items in a Markdown numbered list, handling indentation and
+                numeral style.
+
+                When you use this constructor, the list starts at 1 and uses the specified style.
+
+            .PARAMETER items
+                The items to include in the list.
+
+            .PARAMETER style
+                The style of the numbered list. Valid styles include:
+
+                - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+                  **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+                - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+                  **StartingNumber** for each item, followed by a closing parenthesis. For example,
+                  `1)` or `8)`.
+                - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+                  used for each item in the list, starting with the value of **StartingNumber**. For
+                  example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+                  numeral counts, this style left-pads the shorter numerals with spaces to align
+                  the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+                  numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with spaces to align the closing parenthesis.
+                - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+                  the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+                  increments the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing parenthesis.
+        #>
+
+        $this.Initialize(@{
+            Items = $items
+            Style = $style
+        })
+    }
+
+    NumberedList([int]$startingNumber) {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList starting at the specified number.
+
+            .DESCRIPTION
+                Creates a new NumberedList starting from a number other than 1. An instance of this
+                class is used to render items in a Markdown numbered list, handling indentation and
+                numeral style.
+
+                When you use this constructor, the list starts at the specified number and uses
+                the default style defined as the static **DefaultStyle** property.
+
+            .PARAMETER StartingNumber
+                The number to start the list at. This enables you to create a list that starts at
+                a number other than 1.
+        #>
+
+        $this.Initialize(@{ StartingNumber = $startingNumber })
+    }
+
+    NumberedList([string[]]$items, [int]$startingNumber) {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList with the specified items and starting number.
+
+            .DESCRIPTION
+                Creates a new NumberedList with the specified items and starting number. An instance
+                of this class is used to render items in a Markdown numbered list, handling
+                indentation and numeral style.
+
+                When you use this constructor, the list starts at the specified number and uses
+                the default style defined as the static **DefaultStyle** property.
+
+            .PARAMETER items
+                The items to include in the list.
+
+            .PARAMETER StartingNumber
+                The number to start the list at. This enables you to create a list that starts at
+                a number other than 1.
+        #>
+
+        $this.Initialize(@{
+            Items         = $items
+            StartingNumber = $startingNumber
+        })
+    }
+
+    NumberedList([int]$startingNumber, [NumberedListStyle]$style) {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList with the specified starting number and style.
+
+            .DESCRIPTION
+                Creates a new NumberedList with the specified starting number and style. An
+                instance of this class is used to render items in a Markdown numbered list,
+                handling indentation and numeral style.
+
+                When you use this constructor, the list starts at the specified number and uses
+                the specified style.
+
+            .PARAMETER StartingNumber
+                The number to start the list at. This enables you to create a list that starts at
+                a number other than 1.
+
+            .PARAMETER style
+                The style of the numbered list. Valid styles include:
+
+                - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+                  **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+                - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+                  **StartingNumber** for each item, followed by a closing parenthesis. For example,
+                  `1)` or `8)`.
+                - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+                  used for each item in the list, starting with the value of **StartingNumber**. For
+                  example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+                  numeral counts, this style left-pads the shorter numerals with spaces to align
+                  the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+                  numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with spaces to align the closing parenthesis.
+                - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+                  the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+                  increments the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing parenthesis.
+        #>
+
+        $this.Initialize(@{
+            StartingNumber = $startingNumber
+            Style          = $style
+        })
+    }
+
+    NumberedList([string[]]$items, [int]$startingNumber, [NumberedListStyle]$style) {
+        <#
+            .SYNOPSIS
+                Creates a new NumberedList with the specified items, starting number, and style.
+
+            .DESCRIPTION
+                Creates a new NumberedList with the specified items, starting number, and style. An
+                instance of this class is used to render items in a Markdown numbered list,
+                handling indentation and numeral style.
+
+                When you use this constructor, the list starts at the specified number and uses
+                the specified style.
+
+            .PARAMETER items
+                The items to include in the list.
+
+            .PARAMETER StartingNumber
+                The number to start the list at. This enables you to create a list that starts at
+                a number other than 1.
+
+            .PARAMETER style
+                The style of the numbered list. Valid styles include:
+
+                - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+                  **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+                - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+                  **StartingNumber** for each item, followed by a closing parenthesis. For example,
+                  `1)` or `8)`.
+                - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+                  used for each item in the list, starting with the value of **StartingNumber**. For
+                  example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+                  numeral counts, this style left-pads the shorter numerals with spaces to align
+                  the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+                  numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with spaces to align the closing parenthesis.
+                - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+                  the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+                  increments the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing parenthesis.
+        #>
+
+        $this.Initialize(@{
+            Items          = $items
+            StartingNumber = $startingNumber
+            Style          = $style
+        })
+    }
+
+    [int] GetListNumeralCount() {
+        <#
+            .SYNOPSIS
+                Gets the number of digits to use for each item in the list.
+            .DESCRIPTION
+                Gets the number of digits to use for each item in the list. This is used to
+                determine how much space to pad the numeral with.
+
+                For the following styles, the numeral count is based on the highest numeral in the
+                list, defined as the value of **StartingNumber** plus the number of items in the
+                list:
+
+                - `[NumberedListStyle]::IncrementingNumberPeriod` - For this style, the numeral
+                  count is used to left-pad the numeral with spaces. For example, if the numeral
+                  count is 3, the numeral `1` is rendered as `  1.`.
+                - `[NumberedListStyle]::IncrementingNumberParentheses` - For this style, the numeral
+                  count is used to left-pad the numeral with spaces. For example, if the numeral
+                  count is 3, the numeral `1` is rendered as `  1)`.
+                - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - For this style, the
+                  numeral count is used to left-pad the numeral with zeros. For example, if the
+                  numeral count is 3, the numeral `1` is rendered as `001.`.
+                - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - For this style,
+                  the numeral count is used to left-pad the numeral with zeros. For example, if the
+                  numeral count is 3, the numeral `1` is rendered as `001)`.
+
+                For the styles that use the same numeral for each item in the list, this method
+                returns the numeral count of the **StartingNumber** property.
+        #>
+
+        $numeral = if ($this.Style -le 1) {
+            $this.StartingNumber
+        } else {
+            $this.Items.Length + $this.StartingNumber
+        }
+        $count = switch ($numeral) {
+            { $_ -lt 10 }         { 1 ; break }
+            { $_ -lt 100 }        { 2 ; break }
+            { $_ -lt 1000 }       { 3 ; break }
+            { $_ -lt 10000 }      { 4 ; break }
+            { $_ -lt 100000 }     { 5 ; break }
+            { $_ -lt 1000000 }    { 6 ; break }
+            { $_ -lt 10000000 }   { 7 ; break }
+            { $_ -lt 100000000 }  { 8 ; break }
+            { $_ -lt 1000000000 } { 9 ; break }
+        }
+
+        return $count
+    }
+
+    [string] GetPrefix([int]$itemIndex) {
+        <#
+            .SYNOPSIS
+                Gets the prefix for the specified item.
+
+            .DESCRIPTION
+                Gets the prefix for the specified item. The prefix is the numeral used for the item
+                followed by a period or closing parenthesis, depending on the style.
+
+                Use this overload when you want to get the prefix for an item in the list and
+                automatically determine the numeral to use.
+
+            .PARAMETER itemIndex
+                The index of the item to get the prefix for.
+        #>
+
+        $numeralValue = if ($this.Style -le 1) {
+            $this.StartingNumber
+        } else {
+            $itemIndex + $this.StartingNumber
+        }
+
+        return $this.GetPrefix("$numeralValue")
+    }
+
+    [string] GetPrefix([string]$numeral) {
+        <#
+            .SYNOPSIS
+                Gets the prefix for the specified numeral.
+
+            .DESCRIPTION
+                Gets the prefix for the specified numeral. The prefix is the numeral followed by a
+                period or closing parenthesis, depending on the style.
+
+                Use this overload when you want to get the prefix for a known numeral.
+
+            .PARAMETER numeral
+                The numeral to get the prefix for.
+        #>
+
+        $numeralCount = $this.GetListNumeralCount()
+
+        $formatString = switch ($this.Style) {
+            SameNumberPeriod                        { "{0}. " }
+            SameNumberParentheses                   { "{0}) " }
+            IncrementingNumberPeriod                { "{0,$numeralCount}. " }
+            IncrementingNumberParentheses           { "{0,$numeralCount}) " }
+            IncrementingNumberPeriodZeroPadded      { "{0:$('0' * $numeralCount)}. " }
+            IncrementingNumberParenthesesZeroPadded { "{0:$('0' * $numeralCount)}) " }
+        }
+
+        return ($formatString -f ([int]$numeral))
+    }
+
+    [string[]] FormatListItem([string]$content, [int]$numeral) {
+        <#
+            .SYNOPSIS
+                Formats the specified content as a list item.
+
+            .DESCRIPTION
+                Formats the specified content as a list item. This method is used to format the
+                content of a list item, handling indentation and bullet style.
+
+                Use this overload when you want to format a string as a list item and have the
+                content and numeral already known.
+
+            .PARAMETER content
+                The content to format as a list item.
+
+            .PARAMETER numeral
+                The numeral to use for the list item.
+        #>
+
+        $prefix       = $this.GetPrefix("$numeral")
+
+        return [MarkdownList]::FormatListItem($content, $prefix)
+    }
+
+    [string[]] FormatListItem([int]$index) {
+        <#
+            .SYNOPSIS
+                Formats the specified item as a numbered list entry.
+
+            .DESCRIPTION
+                Formats the specified item as a numbered list entry. This method is used to format
+                the content of a list item, handling indentation and bullet style.
+
+                Use this overload when you want to format an item in the list automatically from
+                the item's index in the list.
+
+            .PARAMETER index
+                The index of the item to format.
+        #>
+
+        $prefix       = $this.GetPrefix($index)
+        $item         = $this.Items[$index]
+
+        return [MarkdownList]::FormatListItem($item, $prefix)
+    }
+
+    [string[]] FormatList() {
+        <#
+            .SYNOPSIS
+                Formats the list as a Markdown numbered list.
+
+            .DESCRIPTION
+                Formats the list as a Markdown numbered list. This method is used to format the list,
+                handling indentation and bullet style.
+
+            .EXAMPLE
+                This example creates a numbered list with three items and formats it.
+
+                ```powershell
+                $list = [NumberedList]::new(@('Item 1', 'Item 2', 'Item 3'))
+                $list.FormatList()
+                ```
+                ```text
+                1. Item 1
+                2. Item 2
+                3. Item 3
+                ```
+        #>
+
+        [string[]]$listLines = @()
+
+        for ($itemIndex = 0 ; $itemIndex -lt $this.Items.Length ; $itemIndex++) {
+            $listLines += $this.FormatListItem($itemIndex)
+        }
+
+        return $listLines
+    }
+
+    static [string[]] FormatList([string[]]$items) {
+        <#
+            .SYNOPSIS
+                Formats the specified items as a Markdown numbered list.
+
+            .DESCRIPTION
+                Formats the specified items as a Markdown numbered list with the default style.
+
+            .PARAMETER items
+                The items to format as a numbered list.
+        #>
+
+        $list = [NumberedList]::new($items)
+
+        return $list.FormatList()
+    }
+
+    static [string[]] FormatList([string[]]$items, [NumberedListStyle]$style) {
+        <#
+            .SYNOPSIS
+                Formats the specified items as a Markdown numbered list with the specified style.
+
+            .DESCRIPTION
+                Formats the specified items as a Markdown numbered list with the specified style.
+
+            .PARAMETER items
+                The items to format as a numbered list.
+
+            .PARAMETER style
+                The style of the numbered list. Valid styles include:
+
+                - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+                  **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+                - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+                  **StartingNumber** for each item, followed by a closing parenthesis. For example,
+                  `1)` or `8)`.
+                - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+                  used for each item in the list, starting with the value of **StartingNumber**. For
+                  example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+                  numeral counts, this style left-pads the shorter numerals with spaces to align
+                  the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+                  numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with spaces to align the closing parenthesis.
+                - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+                  the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+                  increments the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing parenthesis.
+        #>
+
+        $list = [NumberedList]::new($items, $style)
+
+        return $list.FormatList()
+    }
+
+    static [string[]] FormatList([string[]]$items, [int]$startingNumber) {
+        <#
+            .SYNOPSIS
+                Formats the specified items as a Markdown numbered list starting at the specified
+                number.
+
+            .DESCRIPTION
+                Formats the specified items as a Markdown numbered list starting at the specified
+                number.
+
+            .PARAMETER items
+                The items to format as a numbered list.
+
+            .PARAMETER StartingNumber
+                The number to start the list at. This enables you to create a list that starts at
+                a number other than 1.
+        #>
+
+        $list = [NumberedList]::new($items, $startingNumber)
+
+        return $list.FormatList()
+    }
+
+    static [string[]] FormatList(
+        [string[]]$items,
+        [int]$startingNumber,
+        [NumberedListStyle]$style
+    ) {
+        <#
+            .SYNOPSIS
+                Formats the specified items as a Markdown numbered list starting at the specified
+                number with the specified style.
+
+            .DESCRIPTION
+                Formats the specified items as a Markdown numbered list starting at the specified
+                number with the specified style.
+
+            .PARAMETER items
+                The items to format as a numbered list.
+
+            .PARAMETER startingNumber
+                The number to start the list at. This enables you to create a list that starts at
+                a number other than 1.
+
+            .PARAMETER style
+                The style of the numbered list. Valid styles include:
+
+                - `[NumberedListStyle]::SameNumberPeriod` - The list uses the value of
+                  **StartingNumber** for each item, followed by a period. For example, `1.` or `8.`.
+                - `[NumberedListStyle]::SameNumberParentheses` - The list uses the value of
+                  **StartingNumber** for each item, followed by a closing parenthesis. For example,
+                  `1)` or `8)`.
+                - `[NumberedListStyle]::IncrementingNumberPeriod` - The list increments the numeral
+                  used for each item in the list, starting with the value of **StartingNumber**. For
+                  example, `1.`, `2.`, `3.`, etc. For long lists with items that have different
+                  numeral counts, this style left-pads the shorter numerals with spaces to align
+                  the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParentheses` - The list increments the
+                  numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with spaces to align the closing parenthesis.
+                - `[NumberedListStyle]::IncrementingNumberPeriodZeroPadded` - The list increments
+                  the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1.`, `2.`, `3.`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing period.
+                - `[NumberedListStyle]::IncrementingNumberParenthesesZeroPadded` - The list
+                  increments the numeral used for each item in the list, starting with the value of
+                  **StartingNumber**. For example, `1)`, `2)`, `3)`, etc. For long lists with items
+                  that have different numeral counts, this style left-pads the shorter numerals
+                  with zeroes to align the closing parenthesis.
+        #>
+
+        $list = [NumberedList]::new($items, $startingNumber, $style)
+
+        return $list.FormatList()
+    }
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/.LoadOrder.jsonc
@@ -12,7 +12,52 @@
         "IgnoreForTest": false
     },
     {
+        "Name": "SpaceMungingOptions",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
         "Name": "CodeFenceCharacters",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "BulletListStyle",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "NumberedListStyle",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "EmphasisStyle",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "HighlightStyle",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "StrikethroughStyle",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "SubscriptStyle",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "SuperscriptStyle",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "InlineFormatOptions",
         "IgnoreForBuild": false,
         "IgnoreForTest": false
     }

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/BulletListStyle.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/BulletListStyle.psm1
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum BulletListStyle {
+    <#
+        .SYNOPSIS
+            Defines the style to use when turning list items into a Markdown bullet list.
+
+        .DESCRIPTION
+            Defines the style to use when turning list items into a Markdown bullet list. Markdown
+            supports three different characters for bullet lists: hyphens, plus signs, and
+            asterisks.
+
+        .LABEL Hyphen
+            Uses hyphens to create a bullet list. This is the default style. List items look like:
+
+            ```markdown
+            - Item 1
+            - Item 2
+            - Item 3
+            ```
+
+        .LABEL PlusSign
+            Uses plus signs to create a bullet list. List items look like:
+
+            ```markdown
+            + Item 1
+            + Item 2
+            + Item 3
+            ```
+
+        .LABEL Asterisk
+            Uses asterisks to create a bullet list. List items look like:
+
+            ```markdown
+            * Item 1
+            * Item 2
+            * Item 3
+            ```
+    #>
+
+    Hyphen   = 0
+    PlusSign = 1
+    Asterisk = 2
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/CodeFenceCharacters.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/CodeFenceCharacters.psm1
@@ -2,8 +2,33 @@
 # Licensed under the MIT License.
 
 enum CodeFenceCharacters {
-    # The backtick character, maps to `` ` ``.
+    <#
+        .SYNOPSIS
+            Defines the characters to use when creating a Markdown code fence.
+
+        .DESCRIPTION
+            Defines the characters to use when creating a Markdown code fence. Markdown supports
+            two different characters for code fences: backticks and tildes.
+
+        .LABEL Backtick
+            Uses backticks to create a code fence. Code fences look like:
+
+            ``````markdown
+            ```powershell
+            Get-Process
+            ```
+            ``````
+
+        .LABEL Tilde
+            Uses tildes to create a code fence. Code fences look like:
+
+            ``````markdown
+            ~~~powershell
+            Get-Process
+            ~~~
+            ``````
+    #>
+
     Backtick = 0
-    # The tilde character, maps to `~`.
-    Tilde = 1
+    Tilde    = 1
 }

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/EmphasisStyle.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/EmphasisStyle.psm1
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum EmphasisStyle {
+    <#
+        .SYNOPSIS
+            Defines the style to use when emphasizing text in Markdown prose.
+
+        .DESCRIPTION
+            Defines the style to use when emphasizing text in Markdown prose. Markdown supports
+            two different characters for emphasis: underscores and asterisks.
+
+        .LABEL Underscore
+            Uses underscores to emphasize text. This is the default style. Emphasized text looks
+            like:
+
+            ```markdown
+            _This is emphasized text._
+            ```
+
+        .LABEL Asterisk
+            Uses asterisks to emphasize text. Emphasized text looks like:
+
+            ```markdown
+            *This is emphasized text.*
+            ```
+    #>
+
+    Underscore = 0
+    Asterisk   = 1
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/HighlightStyle.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/HighlightStyle.psm1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum HighlightStyle {
+    <#
+        .SYNOPSIS
+            Defines the style to use when highlighting text in Markdown prose.
+
+        .DESCRIPTION
+            Defines the style to use when highlighting text in Markdown prose. Not all Markdown
+            tools support inline highlighting with special syntax. To support the widest range of
+            Markdown tools, the highlight style supports using raw HTML and the sometimes-supported
+            `==` syntax.
+
+        .LABEL HTML
+            Uses raw HTML to highlight text. This is the default style. Highlighted text looks like:
+
+            ```markdown
+            <mark>This is highlighted text.</mark>
+            ```
+
+        .LABEL Equals
+            Uses the `==` syntax to highlight text. Highlighted text looks like:
+
+            ```markdown
+            ==This is highlighted text.==
+            ```
+    #>
+
+    HTML   = 0
+    Equals = 1
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/InlineFormatOptions.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/InlineFormatOptions.psm1
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[Flags()] enum InlineFormatOptions {
+    <#
+        .SYNOPSIS
+            Defines a set of inline formatting options for a snippet of Markdown prose.
+
+        .DESCRIPTION
+            Defines a set of inline formatting options for a snippet of Markdown prose. A snippet
+            of prose can be formatted in multiple ways, such as being emphasized, highlighted,
+            or struck through. This enum defines the set of formatting options that can be applied
+            to the prose as a set of flags.
+
+            This enumeration includes the `GetFlags()` method, which returns an array of the flags
+            that are set on the enumeration value. This is useful for writing code that needs to
+            process each of the flags.
+
+        .LABEL None
+            No formatting options are applied to the prose.
+
+        .LABEL Code
+            The prose is formatted as inline code, equivalent to the `<code>` HTML element.
+
+        .LABEL Emphasize
+            The prose is emphasized, equivalent to the `<em>` HTML element.
+
+        .LABEL Strong
+            The prose is strongly emphasized, equivalent to the `<strong>` HTML element.
+
+        .LABEL Strikethrough
+            The prose is struck through, equivalent to the `<s>` HTML element.
+
+        .LABEL Highlight
+            The prose is highlighted, equivalent to the `<mark>` HTML element.
+
+        .LABEL Superscript
+            The prose is superscripted, equivalent to the `<sup>` HTML element.
+
+        .LABEL Subscript
+            The prose is subscripted, equivalent to the `<sub>` HTML element.
+    #>
+
+    None          = 0
+    Code          = 1
+    Emphasize     = 2
+    Strong        = 4
+    Strikethrough = 8
+    Highlight     = 16
+    Superscript   = 32
+    Subscript     = 64
+}
+
+$MemberDefinition = @{
+    TypeName   = 'InlineFormatOptions'
+    MemberName = 'GetFlags'
+    MemberType = 'ScriptMethod'
+    Value      = {
+        foreach ($Flag in $this.GetType().GetEnumValues()) {
+          if ($this.HasFlag($Flag)) { $Flag }
+        }
+    }
+}
+
+Update-TypeData @MemberDefinition

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/LineEndings.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/LineEndings.psm1
@@ -2,10 +2,25 @@
 # Licensed under the MIT License.
 
 enum LineEndings {
-    # Carriage return line ending, maps to `\r`.
-    CR = 1
-    # Line feed line ending, maps to `\n`.
-    LF = 2
-    # Carriage return and line feed line ending, maps to `\r\n`.
+    <#
+        .SYNOPSIS
+            Defines the line endings to use when writing Markdown prose.
+
+        .DESCRIPTION
+            Defines the line endings to use when writing Markdown prose. Markdown supports three
+            different line endings: carriage return, line feed, and carriage return and line feed.
+
+        .LABEL CR
+            Carriage return line ending, maps to `\r`.
+
+        .LABEL LF
+            Line feed line ending, maps to `\n`.
+
+        .LABEL CRLF
+            Carriage return and line feed line ending, maps to `\r\n`.
+    #>
+
+    CR   = 1
+    LF   = 2
     CRLF = 3
 }

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/NumberedListStyle.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/NumberedListStyle.psm1
@@ -1,0 +1,128 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum NumberedListStyle {
+    <#
+        .SYNOPSIS
+            Defines the style to use when turning list items into a Markdown numbered list.
+
+        .DESCRIPTION
+
+            Defines the style to use when turning list items into a Markdown numbered list.
+            Markdown supports two syntaxes for numbered lists: period and parentheses. Markdown
+            supports using any numerals for the list numbers.
+
+            It's often useful to use the same
+            number for each item in the list, as this enables reordering the items without updating
+            the numbers. When you use a same number style, the list items use the starting list
+            number for every item in the list.
+
+            For lists using an incrementing number instead of the same number, this enumeration
+            supports left-padding the numerals with spaces or zeroes to ensure the list items start
+            at the same column. This only has an affect on longer lists, where the numeral count
+            for the items isn't the same for every item.
+
+        .LABEL SameNumberPeriod
+            Uses periods to create a numbered list with the same number for each item. This is the
+            default style. List items look like:
+
+            ```markdown
+            1. Item 1
+            1. Item 2
+            1. Item 3
+            ```
+
+        .LABEL SameNumberParentheses
+            Uses parentheses to create a numbered list with the same number for each item. List
+            items look like:
+
+            ```markdown
+            1) Item 1
+            1) Item 2
+            1) Item 3
+            ```
+
+        .LABEL IncrementingNumberPeriod
+            Uses periods to create a numbered list with an incrementing number for each item. List
+            items look like:
+
+            ```markdown
+            1. Item 1
+            2. Item 2
+            3. Item 3
+            ```
+
+            For longer lists, this style left-pads the numerals with spaces when needed. List items
+            look like:
+
+            ```markdown
+             8. Item 8
+             9. Item 9
+            10. Item 10
+            ```
+
+        .LABEL IncrementingNumberParentheses
+            Uses parentheses to create a numbered list with an incrementing number for each item.
+            List items look like:
+
+            ```markdown
+            1) Item 1
+            2) Item 2
+            3) Item 3
+            ```
+
+            For longer lists, this style left-pads the numerals with spaces when needed. List items
+            look like:
+
+            ```markdown
+             8) Item 8
+             9) Item 9
+            10) Item 10
+            ```
+
+        .LABEL IncrementingNumberPeriodZeroPadded
+            Uses periods to create a numbered list with an incrementing number for each item.
+
+            ```markdown
+            1. Item 1
+            2. Item 2
+            3. Item 3
+            ```
+
+            For longer lists, this style left-pads the numerals with zeroes when needed. List items
+            look like:
+
+            ```markdown
+            08. Item 8
+            09. Item 9
+            10. Item 10
+            ```
+
+        .LABEL IncrementingNumberParenthesesZeroPadded
+            Uses parentheses to create a numbered list with an incrementing number for each item.
+            List items look like:
+
+            ```markdown
+            1) Item 1
+            2) Item 2
+            3) Item 3
+            ```
+
+            For longer lists, this style left-pads the numerals with zeroes when needed. List items
+            look like:
+
+            ```markdown
+            08) Item 8
+            09) Item 9
+            10) Item 10
+            ```
+    #>
+
+    SameNumberPeriod
+    SameNumberParentheses
+    IncrementingNumberPeriod
+    IncrementingNumberParentheses
+    IncrementingNumberPeriodZeroPadded
+    IncrementingNumberParenthesesZeroPadded
+}
+

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/SpaceMungingOptions.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/SpaceMungingOptions.psm1
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[Flags()] enum SpaceMungingOptions {
+    <#
+        .SYNOPSIS
+            Defines the options to use when munging spaces in Markdown prose.
+
+        .DESCRIPTION
+            Defines the options to use when munging spaces in Markdown prose. When munging spaces,
+            you can control whether to trim spaces at the start and end of the prose. You can also
+            control whether and where to collapse consecutive blank lines into a single empty line.
+
+            By default, no spaces are trimmed and no lines are collapsed.
+
+            This enumeration has alias labels for the most common combinations of options. To trim
+            spaces at the start and end of the prose, use the `TrimBoth` alias. To collapse blank
+            lines at the start and end of the prose, use the `CollapseOuter` alias label. To
+            collapse all blank lines, use the `CollapseAll` alias label.
+
+            This enumeration includes the `GetFlags()` method, which returns an array of the flags
+            that are set on the enumeration value. This is useful for writing code that needs to
+            process the flags.
+
+        .LABEL None
+            No spaces are trimmed and no lines are collapsed. This is the default value.
+
+        .LABEL TrimStart
+            Removes leading horizontal and vertical space characters from the prose. Horizontal
+            space characters include spaces and tabs. Vertical space characters include newlines
+            and carriage returns.
+
+        .LABEL TrimEnd
+            Removes trailing horizontal and vertical space characters from the prose. Horizontal
+            space characters include spaces and tabs. Vertical space characters include newlines
+            and carriage returns.
+
+        .LABEL TrimBoth
+            Removes leading and trailing horizontal and vertical space characters from the prose.
+            Horizontal space characters include spaces and tabs. Vertical space characters include
+            newlines and carriage returns.
+
+        .LABEL CollapseStart
+            Collapses consecutive blank lines at the start of the prose into a single empty line.
+
+        .LABEL CollapseEnd
+            Collapses consecutive blank lines at the end of the prose into a single empty line.
+
+        .LABEL CollapseOuter
+            Collapses consecutive blank lines at the start and end of the prose into a single empty
+            line.
+
+        .LABEL CollapseInner
+            Collapses consecutive blank lines in the middle of the prose into a single empty line.
+
+        .LABEL CollapseAll
+            Collapses all consecutive blank lines in the prose into a single empty line.
+    #>
+
+    None          = 0
+    TrimStart     = 1
+    TrimEnd       = 2
+    TrimBoth      = 3
+    CollapseStart = 4
+    CollapseEnd   = 8
+    CollapseOuter = 12
+    CollapseInner = 16
+    CollapseAll   = 28
+}
+
+$MemberDefinition = @{
+    TypeName   = 'SpaceMungingOptions'
+    MemberName = 'GetFlags'
+    MemberType = 'ScriptMethod'
+    Value      = {
+        foreach ($Flag in $this.GetType().GetEnumValues()) {
+          if ($this.HasFlag($Flag)) { $Flag }
+        }
+    }
+}
+
+Update-TypeData @MemberDefinition

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/StrikethroughStyle.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/StrikethroughStyle.psm1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum StrikethroughStyle {
+    <#
+        .SYNOPSIS
+            Defines the style to use when striking through text in Markdown prose.
+
+        .DESCRIPTION
+            Defines the style to use when striking through text in Markdown prose. Not all Markdown
+            tools support inline striking prose with special syntax. To support the widest range of
+            Markdown tools, the highlight style supports using raw HTML and the sometimes-supported
+            `~~` syntax.
+
+        .LABEL HTML
+            Uses HTML to strike through text. Struck through text looks like:
+
+            ```markdown
+            <s>This is struck through text.</s>
+            ```
+
+        .LABEL Tilde
+            Uses tildes to strike through text. Struck through text looks like:
+
+            ```markdown
+            ~~This is struck through text.~~
+            ```
+    #>
+
+    HTML  = 0
+    Tilde = 1
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/SubscriptStyle.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/SubscriptStyle.psm1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum SubscriptStyle {
+    <#
+        .SYNOPSIS
+            Defines the style to use when subscripting text in Markdown prose.
+
+        .DESCRIPTION
+            Defines the style to use when subscripting text in Markdown prose. Not all Markdown
+            tools support subscripting prose with special syntax. To support the widest range of
+            Markdown tools, the highlight style supports using raw HTML and the sometimes-supported
+            `~` syntax.
+
+        .LABEL HTML
+            Uses HTML to subscript text. Subscripted text looks like:
+
+            ```markdown
+            <sub>This is subscripted text.</sub>
+            ```
+
+        .LABEL Tilde
+            Uses tildes to subscript text. Subscripted text looks like:
+
+            ```markdown
+            ~This is subscripted text.~
+            ```
+    #>
+
+    HTML  = 0
+    Tilde = 1
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/SuperscriptStyle.psm1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Enums/SuperscriptStyle.psm1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+enum SuperscriptStyle {
+    <#
+        .SYNOPSIS
+            Defines the style to use when creating superscript text in Markdown prose.
+
+        .DESCRIPTION
+            Defines the style to use when creating superscript text in Markdown prose. Not all
+            Markdown tools support superscripting prose with special syntax. To support the widest
+            range of Markdown tools, the highlight style supports using raw HTML and the
+            sometimes-supported `^` syntax.
+
+        .LABEL HTML
+            Uses HTML to create superscript text. Superscript text looks like:
+
+            ```markdown
+            This is <sup>superscript</sup> text.
+            ```
+
+        .LABEL Caret
+            Uses a caret to create superscript text. Superscript text looks like:
+
+            ```markdown
+            This is ^superscript^ text.
+            ```
+    #>
+
+    HTML  = 0
+    Caret = 1
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Formats/MarkdownBuilder.Format.ps1xml
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Formats/MarkdownBuilder.Format.ps1xml
@@ -19,6 +19,10 @@
                                 <ScriptBlock> $_.DefaultLineEnding.Value</ScriptBlock>
                             </ListItem>
                             <ListItem>
+                                <Label>SpaceMungingOptions</Label>
+                                <ScriptBlock> $_.SpaceMungingOptions</ScriptBlock>
+                            </ListItem>
+                            <ListItem>
                                 <Label>DefaultFenceCharacter</Label>
                                 <ScriptBlock> $_.DefaultFenceCharacter.Value</ScriptBlock>
                             </ListItem>

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Add-CodeBlock.ps1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Add-CodeBlock.ps1
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Classes/CodeFenceCharacter.psm1
+using module ../Classes/LineEnding.psm1
+using module ../Classes/MarkdownBuilder.psm1
+
+function Add-CodeBlock {
+    [cmdletbinding()]
+    [OutputType([MarkdownBuilder])]
+    param(
+        [string]$Code,
+
+        [string]$Language,
+
+        [parameter(ValueFromPipeline)]
+        [MarkdownBuilder]$Builder,
+
+        [CodeFenceCharacter]$Character,
+
+        [ValidateRange(3, [int]::MaxValue)]
+        [int]$Length,
+
+        [LineEnding]$LineEnding,
+
+        [switch]$PassThru
+    )
+
+    begin {
+        if ($null -eq $Builder) {
+            $NewBuilderParameters = @{}
+            if ($null -ne $Character) {
+                $NewBuilderParameters.DefaultCodeFenceCharacter = $Character
+            }
+            if ($Length -ge 3) {
+                $NewBuilderParameters.DefaultCodeFenceLength = $Length
+            }
+            if ($null -ne $LineEnding) {
+                $NewBuilderParameters.DefaultLineEnding = $LineEnding
+            }
+            $Builder = New-Builder @NewBuilderParameters
+        }
+    }
+
+    process {
+        $PipelinePosition = $PSCmdlet.MyInvocation.PipelinePosition
+        $PipelineLength = $PSCmdlet.MyInvocation.PipelineLength
+
+        if ($PipelineLength -gt 1 -and $PipelinePosition -ne $PipelineLength) {
+            $PassThru = $true
+        }
+
+        if (!$PSBoundParameters.ContainsKey('Character')) {
+            $Character = $Builder.DefaultFenceCharacter
+        }
+        if (!$PSBoundParameters.ContainsKey('Length')) {
+            $Length = $Builder.DefaultFenceLength
+        }
+        if (!$PSBoundParameters.ContainsKey('LineEnding')) {
+            $LineEnding = $Builder.DefaultLineEnding
+        }
+
+        $Updated = $Builder.AppendCodeBlock(
+            $Code,
+            $Language,
+            $Character,
+            $Length,
+            $LineEnding
+        )
+
+        if ($PassThru) {
+            $Updated
+        }
+    }
+
+    end {}
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Add-List.ps1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Add-List.ps1
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Classes/CodeFenceCharacter.psm1
+using module ../Classes/LineEnding.psm1
+using module ../Classes/MarkdownBuilder.psm1
+
+function Add-List {
+    [cmdletbinding(DefaultParameterSetName = 'BulletedList')]
+    [OutputType([MarkdownBuilder])]
+    param(
+        [parameter(ValueFromPipeline, ParameterSetName = 'BulletedList')]
+        [parameter(ValueFromPipeline, ParameterSetName = 'NumberedList')]
+        [MarkdownBuilder]
+        $Builder,
+
+        [Parameter(ParameterSetName = 'BulletedList')]
+        [Parameter(ParameterSetName = 'NumberedList')]
+        [string[]]
+        $ListItem,
+
+        [Parameter(ParameterSetName = 'BulletedList')]
+        [BulletListStyle]
+        $BulletListStyle,
+
+        [Parameter(ParameterSetName = 'NumberedList')]
+        [switch]
+        $AsNumberedList,
+
+        [Parameter(ParameterSetName = 'NumberedList')]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]
+        $StartAt = 1,
+
+        [Parameter(ParameterSetName = 'NumberedList')]
+        [NumberedListStyle]
+        $NumberedListStyle,
+
+        [parameter(ValueFromPipeline, ParameterSetName = 'BulletedList')]
+        [parameter(ValueFromPipeline, ParameterSetName = 'NumberedList')]
+        [LineEnding]
+        $LineEnding,
+
+        [parameter(ValueFromPipeline, ParameterSetName = 'BulletedList')]
+        [parameter(ValueFromPipeline, ParameterSetName = 'NumberedList')]
+        [switch]
+        $PassThru
+    )
+
+    begin {
+        if ($null -eq $Builder) {
+            $NewBuilderParameters = @{}
+            if ($null -ne $LineEnding) {
+                $NewBuilderParameters.DefaultLineEnding = $LineEnding
+            }
+            $Builder = New-Builder @NewBuilderParameters
+        }
+    }
+
+    process {
+        $PipelinePosition = $PSCmdlet.MyInvocation.PipelinePosition
+        $PipelineLength   = $PSCmdlet.MyInvocation.PipelineLength
+
+        if ($PipelineLength -gt 1 -and $PipelinePosition -ne $PipelineLength) {
+            $PassThru = $true
+        }
+
+        $list = [MarkdownList]::new()
+
+        if ($AsNumberedList) {
+            $list = [NumberedList]::new()
+            if ($PSBoundParameters.ContainsKey('NumberedListStyle')) {
+                $list.Style = $NumberedListStyle
+            } else {
+                $list.Style = $Builder.NumberedListStyle
+            }
+            if ($PSBoundParameters.ContainsKey('StartAt')) {
+                $list.StartingNumber = $StartAt
+            }
+            if ($PSBoundParameters.ContainsKey('ListItem')) {
+                $list.Items = $ListItem
+            }
+        } else {
+            $list = [BulletList]::new()
+            if ($PSBoundParameters.ContainsKey('BulletListStyle')) {
+                $list.Style = $BulletListStyle
+            } else {
+                $list.Style = $Builder.BulletListStyle
+            }
+            if ($PSBoundParameters.ContainsKey('ListItem')) {
+                $list.Items = $ListItem
+            }
+        }
+
+        $Updated = if ($PSBoundParameters.ContainsKey('LineEnding')) {
+            $Builder.AppendList($list, $LineEnding)
+        } else {
+            $Builder.AppendList($list)
+        }
+
+        if ($PassThru) {
+            $Updated
+        }
+    }
+
+    end {}
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Add-ListItem.ps1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Add-ListItem.ps1
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Classes/CodeFenceCharacter.psm1
+using module ../Classes/LineEnding.psm1
+using module ../Classes/MarkdownBuilder.psm1
+
+function Add-ListItem {
+    [cmdletbinding(DefaultParameterSetName)]
+    [OutputType([MarkdownBuilder])]
+    param(
+        [parameter(ValueFromPipeline)]
+        [MarkdownBuilder]
+        $Builder,
+
+        [parameter(Mandatory)]
+        [string[]]
+        $ListItem,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $ListIndex,
+
+        [switch]
+        $PassThru
+    )
+
+    begin {
+        if ($null -eq $Builder) {
+            $NewBuilderParameters = @{}
+            if ($null -ne $LineEnding) {
+                $NewBuilderParameters.DefaultLineEnding = $LineEnding
+            }
+            $Builder = New-Builder @NewBuilderParameters
+        }
+    }
+
+    process {
+        $PipelinePosition = $PSCmdlet.MyInvocation.PipelinePosition
+        $PipelineLength   = $PSCmdlet.MyInvocation.PipelineLength
+
+        if ($PipelineLength -gt 1 -and $PipelinePosition -ne $PipelineLength) {
+            $PassThru = $true
+        }
+
+        $listCount     = $Builder.Lists.Count
+        $lastListIndex = $listCount - 1
+
+        if ($listCount -eq 0) {
+            throw [System.InvalidOperationException]::new('No list to add item to.')
+        }
+
+        if ($PSBoundParameters.ContainsKey('ListIndex')) {
+            if ($ListIndex -gt $lastListIndex) {
+                $errorMessage = @(
+                    "The specified list index ($ListIndex) is out of range."
+                    "The maximum index for the builder is $lastListIndex."
+                    "Specify a value between 0 and $lastListIndex."
+                ) -join ' '
+
+                throw [System.ArgumentOutOfRangeException]::new(
+                    'ListIndex',
+                    $ListIndex,
+                    $errorMessage
+                )
+            }
+        } else {
+            $ListIndex = $lastListIndex
+        }
+
+        foreach ($item in $ListItem) {
+            $Updated = $Builder.AddListItem($ListIndex, $item)
+        }
+
+        if ($PassThru) {
+            $Updated
+        }
+    }
+
+    end {}
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/New-Builder.ps1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/New-Builder.ps1
@@ -10,17 +10,68 @@ function New-Builder {
     [OutputType([MarkdownBuilder])]
     param(
         [Parameter(ParameterSetName = 'FromContent')]
-        [string]$Content,
+        [Parameter(ParameterSetName = 'FromContentWithInlineFormatter')]
+        [string]
+        $Content,
 
         [Parameter(ParameterSetName = 'FromStringBuilder')]
-        [System.Text.StringBuilder]$StringBuilder,
+        [Parameter(ParameterSetName = 'FromStringBuilderWithInlineFormatter')]
+        [System.Text.StringBuilder]
+        $StringBuilder,
 
-        [LineEnding]$DefaultLineEnding,
+        [LineEnding]
+        $DefaultLineEnding,
 
-        [CodeFenceCharacter]$DefaultCodeFenceCharacter,
+        [SpaceMungingOptions]
+        $SpaceMungingOptions,
+
+        [CodeFenceCharacter]
+        $DefaultCodeFenceCharacter,
 
         [ValidateRange(3, [int]::MaxValue)]
-        [int]$DefaultCodeFenceLength
+        [int]
+        $DefaultCodeFenceLength,
+
+        [NumberedListStyle]
+        $NumberedListStyle,
+
+        [BulletListStyle]
+        $BulletListStyle,
+
+        [Parameter(ParameterSetName = 'FromContentWithInlineFormatter')]
+        [Parameter(ParameterSetName = 'FromStringBuilderWithInlineFormatter')]
+        [InlineFormatter]
+        $InlineFormatter,
+
+        [Parameter(ParameterSetName = 'FromContent')]
+        [Parameter(ParameterSetName = 'FromStringBuilder')]
+        [EmphasisStyle]
+        $EmphasisStyle,
+
+        [Parameter(ParameterSetName = 'FromContent')]
+        [Parameter(ParameterSetName = 'FromStringBuilder')]
+        [EmphasisStyle]
+        $StrongStyle,
+
+        [Parameter(ParameterSetName = 'FromContent')]
+        [Parameter(ParameterSetName = 'FromStringBuilder')]
+        [StrikethroughStyle]
+        $StrikethroughStyle,
+
+        [Parameter(ParameterSetName = 'FromContent')]
+        [Parameter(ParameterSetName = 'FromStringBuilder')]
+        [HighlightStyle]
+        $HighlightStyle,
+
+        [Parameter(ParameterSetName = 'FromContent')]
+        [Parameter(ParameterSetName = 'FromStringBuilder')]
+        [SubscriptStyle]
+        $SubscriptStyle,
+
+        [Parameter(ParameterSetName = 'FromContent')]
+        [Parameter(ParameterSetName = 'FromStringBuilder')]
+        [SuperscriptStyle]
+        $SuperscriptStyle
     )
 
     begin {}
@@ -34,7 +85,7 @@ function New-Builder {
             [MarkdownBuilder]::new()
         }
 
-        if ($null -ne $DefaultCodeFenceCharacter) {
+        if ($PSBoundParameters.ContainsKey('DefaultCodeFenceCharacter')) {
             $Builder.DefaultFenceCharacter = $DefaultCodeFenceCharacter
         }
 
@@ -42,8 +93,48 @@ function New-Builder {
             $Builder.DefaultFenceLength = $DefaultCodeFenceLength
         }
 
-        if ($null -ne $DefaultLineEnding) {
+        if ($PSBoundParameters.ContainsKey('DefaultLineEnding')) {
             $Builder.DefaultLineEnding = $DefaultLineEnding
+        }
+
+        if ($PSBoundParameters.ContainsKey('SpaceMungingOptions')) {
+            $Builder.SpaceMungingOptions = $SpaceMungingOptions
+        }
+
+        if ($PSBoundParameters.ContainsKey('NumberedListStyle')) {
+            $Builder.NumberedListStyle = $NumberedListStyle
+        }
+
+        if ($PSBoundParameters.ContainsKey('BulletListStyle')) {
+            $Builder.BulletListStyle = $BulletListStyle
+        }
+
+        if ($PSBoundParameters.ContainsKey('InlineFormatter')) {
+            $Builder.InlineFormatter = $InlineFormatter
+        }
+
+        if ($PSBoundParameters.ContainsKey('EmphasisStyle')) {
+            $Builder.InlineFormatter.EmphasisStyle = $EmphasisStyle
+        }
+
+        if ($PSBoundParameters.ContainsKey('StrongStyle')) {
+            $Builder.InlineFormatter.StrongStyle = $StrongStyle
+        }
+
+        if ($PSBoundParameters.ContainsKey('StrikethroughStyle')) {
+            $Builder.InlineFormatter.StrikethroughStyle = $StrikethroughStyle
+        }
+
+        if ($PSBoundParameters.ContainsKey('HighlightStyle')) {
+            $Builder.InlineFormatter.HighlightStyle = $HighlightStyle
+        }
+
+        if ($PSBoundParameters.ContainsKey('SubscriptStyle')) {
+            $Builder.InlineFormatter.SubscriptStyle = $SubscriptStyle
+        }
+
+        if ($PSBoundParameters.ContainsKey('SuperscriptStyle')) {
+            $Builder.InlineFormatter.SuperscriptStyle = $SuperscriptStyle
         }
 
         $Builder

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Start-List.ps1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Start-List.ps1
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Classes/CodeFenceCharacter.psm1
+using module ../Classes/LineEnding.psm1
+using module ../Classes/MarkdownBuilder.psm1
+
+function Start-List {
+    [cmdletbinding(DefaultParameterSetName = 'BulletedList')]
+    [OutputType([MarkdownBuilder])]
+    param(
+        [parameter(ValueFromPipeline, ParameterSetName = 'BulletedList')]
+        [parameter(ValueFromPipeline, ParameterSetName = 'NumberedList')]
+        [MarkdownBuilder]
+        $Builder,
+
+        [Parameter(ParameterSetName = 'BulletedList')]
+        [BulletListStyle]
+        $BulletListStyle,
+
+        [Parameter(ParameterSetName = 'NumberedList')]
+        [switch]
+        $AsNumberedList,
+
+        [Parameter(ParameterSetName = 'NumberedList')]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]
+        $StartAt = 1,
+
+        [Parameter(ParameterSetName = 'NumberedList')]
+        [NumberedListStyle]
+        $NumberedListStyle,
+
+        [parameter(ValueFromPipeline, ParameterSetName = 'BulletedList')]
+        [parameter(ValueFromPipeline, ParameterSetName = 'NumberedList')]
+        [LineEnding]
+        $LineEnding,
+
+        [parameter(ValueFromPipeline, ParameterSetName = 'BulletedList')]
+        [parameter(ValueFromPipeline, ParameterSetName = 'NumberedList')]
+        [switch]
+        $PassThru
+    )
+
+    begin {
+        if ($null -eq $Builder) {
+            $NewBuilderParameters = @{}
+            if ($null -ne $LineEnding) {
+                $NewBuilderParameters.DefaultLineEnding = $LineEnding
+            }
+            $Builder = New-Builder @NewBuilderParameters
+        }
+    }
+
+    process {
+        $PipelinePosition = $PSCmdlet.MyInvocation.PipelinePosition
+        $PipelineLength   = $PSCmdlet.MyInvocation.PipelineLength
+
+        if ($PipelineLength -gt 1 -and $PipelinePosition -ne $PipelineLength) {
+            $PassThru = $true
+        }
+
+        $specifiedBulletStyle = $PSBoundParameters.ContainsKey('BulletListStyle')
+        $specifiedNumberStyle = $PSBoundParameters.ContainsKey('NumberedListStyle')
+        $specifiedNumberStart = $PSBoundParameters.ContainsKey('StartAt')
+
+        $Updated = if ($AsNumberedList -and $specifiedNumberStyle -and $specifiedNumberStart) {
+            $Builder.StartNumberedList($StartAt, $NumberedListStyle)
+        } elseif ($AsNumberedList -and $specifiedNumberStart) {
+            $Builder.StartNumberedList($StartAt)
+        } elseif ($AsNumberedList -and $specifiedNumberStyle) {
+            $Builder.StartNumberedList($NumberedListStyle)
+        } elseif ($AsNumberedList) {
+            $Builder.StartNumberedList()
+        } elseif ($specifiedBulletStyle) {
+            $Builder.StartBulletList($BulletListStyle)
+        } else {
+            $Builder.StartBulletList()
+        }
+
+        if ($PassThru) {
+            $Updated
+        }
+    }
+
+    end {}
+}

--- a/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Stop-List.ps1
+++ b/Projects/Modules/Documentarian.MarkdownBuilder/Source/Public/Functions/Stop-List.ps1
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ../Classes/LineEnding.psm1
+using module ../Classes/MarkdownBuilder.psm1
+
+function Stop-List {
+    [cmdletbinding()]
+    [OutputType([MarkdownBuilder])]
+    param(
+        [parameter(ValueFromPipeline)]
+        [MarkdownBuilder]$Builder,
+
+        [LineEnding]$LineEnding,
+
+        [switch]$PassThru
+    )
+
+    begin {
+        if ($null -eq $Builder) {
+            $Builder = New-Builder
+            if ($null -ne $LineEnding) {
+                $Builder.DefaultLineEnding = $LineEnding
+            }
+        }
+    }
+
+    process {
+        $PipelinePosition = $PSCmdlet.MyInvocation.PipelinePosition
+        $PipelineLength   = $PSCmdlet.MyInvocation.PipelineLength
+
+        if ($PipelineLength -gt 1 -and $PipelinePosition -ne $PipelineLength) {
+            $PassThru = $true
+        }
+
+        $Updated = if ($Builder.Lists.Count -gt 0) {
+            if ($null -ne $LineEnding) {
+                $Builder.EndList($LineEnding)
+            } else {
+                $Builder.EndList()
+            }
+        } else {
+            Write-Warning 'No list to close. Ignoring.'
+            $Builder
+        }
+
+        if ($PassThru) {
+            $Updated
+        }
+    }
+
+    end {}
+}

--- a/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
+++ b/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
@@ -12,7 +12,8 @@
     "PowerShellVersion": "7.2",
     "RequiredModules": [
       "Documentarian.MarkdownBuilder",
-      "Documentarian.MicrosoftDocs"
+      "Documentarian.MicrosoftDocs",
+      "Yayaml"
     ],
     "Tags": [
       "Markdown",

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/.LoadOrder.jsonc
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/.LoadOrder.jsonc
@@ -165,6 +165,18 @@
         "IgnoreForTest": false
     },
     {
+        "Name": "HelpInfoFormatter",
+        "Folder": "HelpInfo",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
+        "Name": "HelpInfoFormatterDictionary",
+        "Folder": "HelpInfo",
+        "IgnoreForBuild": false,
+        "IgnoreForTest": false
+    },
+    {
         "Name": "AttributeHelpInfo",
         "Folder": "HelpInfo",
         "IgnoreForBuild": false,

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/AstTypeTransformAttribute.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/AstTypeTransformAttribute.psm1
@@ -5,14 +5,14 @@
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstType.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Test-IsAstType.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstType.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Test-IsAstType.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingComment.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingComment.psm1
@@ -5,6 +5,7 @@ using namespace System.Management.Automation.Language
 using namespace System.Collections.Generic
 using namespace System.Collections.Specialized
 using module ./DecoratingComments.psm1
+using module ./DecoratingCommentsBlockParsed.psm1
 using module ./DecoratingCommentsRegistry.psm1
 
 class DecoratingComment {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingComments.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingComments.psm1
@@ -4,6 +4,7 @@
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Generic
 using namespace System.Collections.Specialized
+using module ../AstInfo.psm1
 
 class DecoratingComments {
     static [bool] CanHaveCommentBlockInside([Ast]$targetAst) {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockKeywords.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockKeywords.psm1
@@ -150,11 +150,11 @@ class DecoratingCommentsBlockKeywords {
     hidden static [string] ExternalHelpPattern() {
         return @(
             '('
-                '\S+'   # Matches a bare string without spaces
-                '|'
-                '".*"'  # Matches a double-quoted string
-                '|'
-                "'.*'"  # Matches a single-quoted string
+            '    \S+'.TrimStart()   # Matches a bare string without spaces
+            '    |'.TrimStart()
+            '    ".*"'.TrimStart()  # Matches a double-quoted string
+            '    |'.TrimStart()
+            "    '.*'".TrimStart()  # Matches a single-quoted string
             ')'
         ) -join ''
     }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockParsed.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockParsed.psm1
@@ -2,8 +2,6 @@
 # Licensed under the MIT License.
 
 using namespace System.Collections.Specialized
-using module ../../Enums/DecoratingCommentsBlockKeywordKind.psm1
-using module ./DecoratingCommentsBlockKeyword.psm1
 using module ./DecoratingCommentsBlockKeyword.psm1
 
 class DecoratingCommentsBlockParsed : System.Collections.Specialized.OrderedDictionary {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockSchema.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockSchema.psm1
@@ -3,8 +3,8 @@
 
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
-using module ./DecoratingCommentsBlockParsed.psm1
 using module ./DecoratingCommentsBlockKeyword.psm1
+using module ./DecoratingCommentsBlockParsed.psm1
 
 class DecoratingCommentsBlockSchema {
     <#

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockSchema.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsBlockSchema.psm1
@@ -307,13 +307,13 @@ class DecoratingCommentsBlockSchema {
         $CleanedComment = [DecoratingCommentsBlockSchema]::CleanCommentBlock($comment)
 
         $Result = $CleanedComment |
-        Select-String -Pattern $pattern -AllMatches |
-        ForEach-Object -Process { $_.Matches.Groups } |
-        Where-Object -FilterScript { $_.Name -eq 'Content' } |
-        Select-Object -ExpandProperty Value |
-        ForEach-Object -Process {
-            [DecoratingCommentsBlockSchema]::MungeKeywordBlock($_)
-        }
+            Select-String -Pattern $pattern -AllMatches |
+            ForEach-Object -Process { $_.Matches.Groups } |
+            Where-Object -FilterScript { $_.Name -eq 'Content' } |
+            Select-Object -ExpandProperty Value |
+            ForEach-Object -Process {
+                [DecoratingCommentsBlockSchema]::MungeKeywordBlock($_)
+            }
 
         return $Result
     }
@@ -334,13 +334,13 @@ class DecoratingCommentsBlockSchema {
         $CleanedComment = [DecoratingCommentsBlockSchema]::CleanCommentBlock($comment)
 
         $Result = $CleanedComment |
-        Select-String -Pattern $pattern -AllMatches |
-        ForEach-Object -Process { $_.Matches.Groups } |
-        Where-Object -FilterScript { $_.Name -eq 'Value' } |
-        Select-Object -ExpandProperty Value |
-        ForEach-Object -Process {
-            $_.Trim()
-        }
+            Select-String -Pattern $pattern -AllMatches |
+            ForEach-Object -Process { $_.Matches.Groups } |
+            Where-Object -FilterScript { $_.Name -eq 'Value' } |
+            Select-Object -ExpandProperty Value |
+            ForEach-Object -Process {
+                $_.Trim()
+            }
 
         return $Result
     }
@@ -349,9 +349,9 @@ class DecoratingCommentsBlockSchema {
         $CleanedComment = [DecoratingCommentsBlockSchema]::CleanCommentBlock($comment)
 
         if ($CleanedComment -match $pattern) {
-            $Entry = [DecoratingCommentsBlockParsed]::new()
-            $Value = $Matches.Value.Trim()
+            $Entry   = [DecoratingCommentsBlockParsed]::new()
             $Content = [DecoratingCommentsBlockSchema]::MungeKeywordBlock($Matches.Content)
+            $Value   = $Matches.Value.Trim()
             $Entry.Add('Value', $Value)
             $Entry.Add('Content', $Content)
             return $Entry
@@ -364,18 +364,18 @@ class DecoratingCommentsBlockSchema {
         $CleanedComment = [DecoratingCommentsBlockSchema]::CleanCommentBlock($comment)
 
         $Result = $CleanedComment |
-        Select-String -Pattern $pattern -AllMatches |
-        Select-Object -ExpandProperty Matches |
-        ForEach-Object -Process {
-            $Value = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Value' }
-            $Content = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Content' }
-            $Value = $Value.Value.Trim()
-            $Content = [DecoratingCommentsBlockSchema]::MungeKeywordBlock($Content.Value)
-            $Entry = [DecoratingCommentsBlockParsed]::new()
-            $Entry.Add('Value', $Value)
-            $Entry.Add('Content', $Content)
-            $Entry
-        }
+            Select-String -Pattern $pattern -AllMatches |
+            Select-Object -ExpandProperty Matches |
+            ForEach-Object -Process {
+                $Value   = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Value' }
+                $Content = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Content' }
+                $Value   = $Value.Value.Trim()
+                $Content = [DecoratingCommentsBlockSchema]::MungeKeywordBlock($Content.Value)
+                $Entry   = [DecoratingCommentsBlockParsed]::new()
+                $Entry.Add('Value', $Value)
+                $Entry.Add('Content', $Content)
+                $Entry
+            }
 
         return $Result
     }
@@ -384,9 +384,9 @@ class DecoratingCommentsBlockSchema {
         $CleanedComment = [DecoratingCommentsBlockSchema]::CleanCommentBlock($comment)
 
         if ($CleanedComment -match $pattern) {
-            $Entry = [DecoratingCommentsBlockParsed]::new()
-            $Value = if ($Matches.Value) { $Matches.Value.Trim() } else { '' }
+            $Entry   = [DecoratingCommentsBlockParsed]::new()
             $Content = [DecoratingCommentsBlockSchema]::MungeKeywordBlock($Matches.Content)
+            $Value   = if ($Matches.Value) { $Matches.Value.Trim() } else { '' }
             $Entry.Add('Value', $Value)
             $Entry.Add('Content', $Content)
             return $Entry
@@ -402,24 +402,24 @@ class DecoratingCommentsBlockSchema {
         $CleanedComment = [DecoratingCommentsBlockSchema]::CleanCommentBlock($comment)
 
         $Result = $CleanedComment |
-        Select-String -Pattern $pattern -AllMatches |
-        Select-Object -ExpandProperty Matches |
-        ForEach-Object -Process {
-            $Value = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Value' }
-            $Content = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Content' }
-            $Value = if ($Value.Value) { $Value.Value.Trim() } else { '' }
-            $Content = [DecoratingCommentsBlockSchema]::MungeKeywordBlock($Content.Value)
-            $Entry = [DecoratingCommentsBlockParsed]::new()
-            $Entry.Add('Value', $Value)
-            $Entry.Add('Content', $Content)
-            $Entry
-        }
+            Select-String -Pattern $pattern -AllMatches |
+            Select-Object -ExpandProperty Matches |
+            ForEach-Object -Process {
+                $Value   = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Value' }
+                $Content = $_.Groups | Where-Object -FilterScript { $_.Name -eq 'Content' }
+                $Value   = if ($Value.Value) { $Value.Value.Trim() } else { '' }
+                $Content = [DecoratingCommentsBlockSchema]::MungeKeywordBlock($Content.Value)
+                $Entry   = [DecoratingCommentsBlockParsed]::new()
+                $Entry.Add('Value', $Value)
+                $Entry.Add('Content', $Content)
+                $Entry
+            }
 
         return $Result
     }
 
     static [string] MungeKeywordBlock([string]$content) {
-        $Lines = [System.Collections.Generic.List[string]]::new()
+        $Lines                      = [System.Collections.Generic.List[string]]::new()
         $LookingForFirstContentLine = $true
 
         foreach ($Line in ($Content -split '\r?\n')) {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsPatterns.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsPatterns.psm1
@@ -59,7 +59,7 @@ class DecoratingCommentsPatterns {
     static [string] GetBlockKeywordPattern([string]$keyword) {
         return @(
             [DecoratingCommentsPatterns]::RegexMode()
-            "^\s*\.${keyword}\s*$"      # Match the specific key declaration only.
+            "^[ \t]*\.${keyword}[ \t]*$"      # Match the specific key declaration only.
             [DecoratingCommentsPatterns]::GetBlockContentPattern()
         ) -join ''
     }
@@ -74,7 +74,7 @@ class DecoratingCommentsPatterns {
     static [string] GetBlockAndValueKeywordPattern([string]$keyword, [regex]$pattern) {
         return @(
             [DecoratingCommentsPatterns]::RegexMode()
-            "^\s*\.${keyword}\s*(?<Value>${pattern})\s*$"
+            "^[ \t]*\.${keyword}[ \t]*(?<Value>${pattern})[ \t]*$"
             [DecoratingCommentsPatterns]::GetBlockContentPattern()
         ) -join ''
     }
@@ -89,7 +89,7 @@ class DecoratingCommentsPatterns {
     static [string] GetBlockAndOptionalValueKeywordPattern([string]$keyword, [regex]$pattern) {
         return @(
             [DecoratingCommentsPatterns]::RegexMode()
-            "^\s*\.${keyword}\s*(?<Value>${pattern})?\s*$"
+            "^[ \t]*\.${keyword}[ \t]*(?<Value>${pattern})?[ \t]*$"
             [DecoratingCommentsPatterns]::GetBlockContentPattern()
         ) -join ''
     }
@@ -101,9 +101,9 @@ class DecoratingCommentsPatterns {
     static [string] GetValueKeywordPattern([string]$keyword, [regex]$pattern) {
         return @(
             [DecoratingCommentsPatterns]::RegexMode()
-            "^\s*\.${keyword}\s*"
+            "^[ \t]*\.${keyword}[ \t]*"
             [DecoratingCommentsPatterns]::GetValueContentPattern($pattern)
-            '\s*$'
+            '[ \t]*$'
         ) -join ''
     }
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsPatterns.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsPatterns.psm1
@@ -108,17 +108,12 @@ class DecoratingCommentsPatterns {
     }
 
     # Set the regex modes for the patterns used in this class.
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-        <#Category#>'PSUseConsistentIndentation',
-        <#CheckId#>$null,
-        Justification = 'Easier readability for regex strings from arrays'
-    )]
     hidden static [string] RegexMode() {
         return @(
-            '(?'
-                'm' # ^ and $ match start/end of line, not string.
-                'n' # Don't capture unnamed groups.
-            ')'
+            '(?'                 # Start mode declaration
+            '    m'.TrimStart()  # ^ and $ match start/end of line, not string.
+            '    n'.TrimStart()  # Don't capture unnamed groups.
+            ')'                  # End mode declaration
         ) -join ''
     }
 
@@ -134,18 +129,13 @@ class DecoratingCommentsPatterns {
         return "(?<Value>${pattern})"
     }
 
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-        <#Category#>'PSUseConsistentIndentation',
-        <#CheckId#>$null,
-        Justification = 'Easier readability for regex strings from arrays'
-    )]
     hidden static [string] NegativeLookAhead([string]$keywordMatch) {
         return @(
-            '(?!'                   # Don't capture if this sub pattern matches:
-                '\s*'               # Any whitespace, including newlines
-                '^\s*'              # A line with any leading whitespace
-                "\.$KeywordMatch"   # A line that starts with another keyword.
-            ')'                     # Close negative lookahead.
+            '(?!'                             # Don't capture if this sub pattern matches:
+            '    \s*'.TrimStart()             #     Any whitespace, including newlines
+            '    ^\s*'.TrimStart()            #     A line with any leading whitespace
+            "    \.$KeywordMatch".TrimStart() #     A line that starts with another keyword.
+            ')'                               # Close negative lookahead.
         ) -join ''
     }
 
@@ -159,20 +149,15 @@ class DecoratingCommentsPatterns {
         )
     }
 
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-        <#Category#>'PSUseConsistentIndentation',
-        <#CheckId#>$null,
-        Justification = 'Easier readability for regex strings from arrays'
-    )]
     hidden static [string] BlockContentPattern([string]$negativeLookAhead) {
         return @(
-            '(?<Content>'               # Open capture group for the key's content.
-                '('
-                    '(\s|.)'            # Match any character, including newlines, unless the
-                    $negativeLookAhead  # negative lookahead pattern matches.
-                ')+'                    # Match at least once, greedily.
-                '.?'                    # Match the last character that was potentially missed.
-            ')'
+            '(?<Content>'.TrimStart()                # Open capture group for the key's content.
+            '    ('.TrimStart()                      # Open group to match with negative lookahead.
+            '        (\s|.)'.TrimStart()             # Match any character, including newlines,
+            "        $negativeLookAhead".TrimStart() # unless the negative lookahead pattern matches.
+            '    )+'.TrimStart()                     # Match the group at least once, greedily.
+            '    .?'.TrimStart()                     # Match the last character that was potentially missed.
+            ')'                                      # Close the capture group.
         ) -join ''
     }
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
@@ -222,7 +222,8 @@ class DecoratingCommentsRegistry {
         return [DecoratingCommentsRegistry]::new()
     }
 
-    static [DecoratingCommentsRegistry] $Global = $Global:ModuleAuthorDecoratingCommentsRegistry
+    static [DecoratingCommentsRegistry]
+    $Global = $Global:ModuleAuthorDecoratingCommentsRegistry
 
     [DecoratingCommentsBlockSchema] GetDefaultSchema() {
         if ($RegisteredDefaultSchema = $this.GetRegisteredSchema('Default')) {
@@ -339,16 +340,25 @@ class DecoratingCommentsRegistry {
 
     [DecoratingCommentsBlockParsed] ParseDecoratingCommentBlock([string]$comment) {
         $Schema = $this.SelectSchema($comment)
+
         return $Schema.Parse($comment)
     }
 
-    [DecoratingCommentsBlockParsed] ParseDecoratingCommentBlock([string]$comment, [string]$schemaName) {
+    [DecoratingCommentsBlockParsed] ParseDecoratingCommentBlock(
+        [string]$comment,
+        [string]$schemaName
+    ) {
         $Schema = $this.SelectSchema($comment, $schemaName)
+
         return $Schema.Parse($comment)
     }
 
-    [DecoratingCommentsBlockParsed] ParseDecoratingCommentBlock([string]$comment, [ast]$decoratedAst) {
+    [DecoratingCommentsBlockParsed] ParseDecoratingCommentBlock(
+        [string]$comment,
+        [ast]$decoratedAst
+    ) {
         $Schema = $this.SelectSchema($comment, $decoratedAst)
+
         return $Schema.Parse($comment)
     }
 
@@ -358,6 +368,7 @@ class DecoratingCommentsRegistry {
         [ast]$decoratedAst
     ) {
         $Schema = $this.SelectSchema($comment, $schemaName, $decoratedAst)
+
         return $Schema.Parse($comment)
     }
 
@@ -393,7 +404,7 @@ class DecoratingCommentsRegistry {
             $this.Keywords.Add($keyword)
             $IsRegistered = $true
         } elseif ($force) {
-            $index = $this.Keywords.FindIndex({ $args[0].Name -eq $keyword.Name })
+            $index = $this.Keywords.FindIndex{ $args[0].Name -eq $keyword.Name }
             $this.Keywords[$index] = $keyword
             $IsRegistered = $true
         }
@@ -471,9 +482,9 @@ class DecoratingCommentsRegistry {
             $this.Schemas.Add($schema)
             $RegisteredSchema = $true
         } elseif ($force) {
-            $index = $this.Schemas.FindIndex({
+            $index = $this.Schemas.FindIndex{
                 ($args[0] -as [DecoratingCommentsBlockSchema]).GetName() -eq $schema.GetName()
-            })
+            }
             $this.Schemas[$index] = $schema
             $RegisteredSchema = $true
         }
@@ -590,6 +601,7 @@ class DecoratingCommentsRegistry {
 
     [bool] UnregisterKeyword([string]$name) {
         $keyword = $this.GetRegisteredKeyword($name)
+
         return $this.UnregisterKeyword($keyword)
     }
 
@@ -599,6 +611,7 @@ class DecoratingCommentsRegistry {
 
     [bool] UnregisterSchema([string]$schemaValue) {
         $schema = $this.GetRegisteredSchema($schemaValue)
+
         return $this.UnregisterSchema($schema)
     }
 
@@ -608,6 +621,7 @@ class DecoratingCommentsRegistry {
 
     [bool] UnregisterSchemaByAlias([string]$alias) {
         $schema = $this.GetRegisteredSchemaByAlias($alias)
+
         return $this.UnregisterSchema($schema)
     }
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
@@ -7,6 +7,7 @@ using namespace System.Collections.Specialized
 using module ./DecoratingComments.psm1
 using module ./DecoratingCommentsBlockKeyword.psm1
 using module ./DecoratingCommentsBlockKeywords.psm1
+using module ./DecoratingCommentsBlockParsed.psm1
 using module ./DecoratingCommentsBlockSchema.psm1
 using module ./Schemas/DecoratingCommentsBlockSchemasClass.psm1
 using module ./Schemas/DecoratingCommentsBlockSchemasClassOverload.psm1

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/Schemas/DecoratingCommentsBlockSchemasClassOverload.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/DecoratingComments/Schemas/DecoratingCommentsBlockSchemasClassOverload.psm1
@@ -8,7 +8,7 @@ using module ../DecoratingCommentsBlockKeywords.psm1
 using module ../DecoratingCommentsBlockSchema.psm1
 
 class DecoratingCommentsBlockSchemasClassOverload : DecoratingCommentsBlockSchema {
-  <#
+    <#
         .SYNOPSIS
         Represents the schema for a comment decorating an overload in a class.
 
@@ -36,7 +36,7 @@ class DecoratingCommentsBlockSchemasClassOverload : DecoratingCommentsBlockSchem
           text after it. Specify the keyword once for each exception.
     #>
 
-  <#
+    <#
         .SYNOPSIS
         The name of the parser schema to use for a decorated comment.
 
@@ -52,9 +52,9 @@ class DecoratingCommentsBlockSchemasClassOverload : DecoratingCommentsBlockSchem
         If a decorated comment doesn't declare the `Schema` keyword, the caller
         needs to decide which schema to use based on the current context.
     #>
-  static [string] $Name = 'ClassOverload'
+    static [string] $Name = 'ClassOverload'
 
-  <#
+    <#
         .SYNOPSIS
         A list of alternate names for the parser schema.
 
@@ -71,12 +71,12 @@ class DecoratingCommentsBlockSchemasClassOverload : DecoratingCommentsBlockSchem
         needs to decide which schema to use based on the current context.
 
     #>
-  static [string[]] $Aliases = @(
-    'ClassConstructor'
-    'ClassMethod'
-  )
+    static [string[]] $Aliases = @(
+        'ClassConstructor'
+        'ClassMethod'
+    )
 
-  <#
+    <#
         .SYNOPSIS
         The Keywords this schema uses for retrieving documentation from a
         comment.
@@ -86,11 +86,11 @@ class DecoratingCommentsBlockSchemasClassOverload : DecoratingCommentsBlockSchem
         that this schema recognizes when parsing a comment block decorating
         a code snippet.
     #>
-  static [DecoratingCommentsBlockKeyword[]] $Keywords = @(
-    [DecoratingCommentsBlockKeywords]::Synopsis
-    [DecoratingCommentsBlockKeywords]::Description
-    [DecoratingCommentsBlockKeywords]::Example
-    [DecoratingCommentsBlockKeywords]::Parameter
-    [DecoratingCommentsBlockKeywords]::Exception
-  )
+    static [DecoratingCommentsBlockKeyword[]] $Keywords = @(
+        [DecoratingCommentsBlockKeywords]::Synopsis
+        [DecoratingCommentsBlockKeywords]::Description
+        [DecoratingCommentsBlockKeywords]::Example
+        [DecoratingCommentsBlockKeywords]::Parameter
+        [DecoratingCommentsBlockKeywords]::Exception
+    )
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/AttributeHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/AttributeHelpInfo.psm1
@@ -10,13 +10,13 @@ using module ./BaseHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -28,8 +28,8 @@ class AttributeHelpInfo : BaseHelpInfo {
     [string] $Definition
 
     AttributeHelpInfo() {}
-    AttributeHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+
+    AttributeHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     AttributeHelpInfo([AttributeAst]$attributeAst) {
         $this.Initialize($attributeAst)
@@ -58,7 +58,7 @@ class AttributeHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Type = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Type       = $metadata.Type       | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
         $metadata.Definition = $metadata.Definition | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/AttributeHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/AttributeHelpInfo.psm1
@@ -28,6 +28,8 @@ class AttributeHelpInfo : BaseHelpInfo {
     [string] $Definition
 
     AttributeHelpInfo() {}
+    AttributeHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     AttributeHelpInfo([AttributeAst]$attributeAst) {
         $this.Initialize($attributeAst)

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/AttributeHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/AttributeHelpInfo.psm1
@@ -54,4 +54,11 @@ class AttributeHelpInfo : BaseHelpInfo {
 
         return @()
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Type = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Definition = $metadata.Definition | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/BaseHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/BaseHelpInfo.psm1
@@ -4,6 +4,15 @@
 using namespace System.Collections.Specialized
 
 class BaseHelpInfo {
+
+    BaseHelpInfo() {}
+
+    BaseHelpInfo([OrderedDictionary]$metadata) {
+        foreach ($Property in $metadata.Keys) {
+            $this.$Property = $metadata.$Property
+        }
+    }
+
     [OrderedDictionary] ToMetadataDictionary() {
         return $this.ToMetadataDictionary($false)
     }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/BaseHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/BaseHelpInfo.psm1
@@ -5,6 +5,10 @@ using namespace System.Collections.Specialized
 
 class BaseHelpInfo {
     [OrderedDictionary] ToMetadataDictionary() {
+        return $this.ToMetadataDictionary($false)
+    }
+
+    [OrderedDictionary] ToMetadataDictionary([bool]$AddYamlFormatting) {
         $Metadata = [OrderedDictionary]::new([System.StringComparer]::OrdinalIgnoreCase)
 
         foreach ($Property in $this.GetType().GetProperties()) {
@@ -18,7 +22,16 @@ class BaseHelpInfo {
                 continue
             }
 
-            [BaseHelpInfo]::AddToMetadataDictionary($Metadata, $PropertyName, $PropertyValue)
+            [BaseHelpInfo]::AddToMetadataDictionary(
+                $Metadata,
+                $PropertyName,
+                $PropertyValue,
+                $AddYamlFormatting
+            )
+        }
+
+        if ($AddYamlFormatting -and $null -ne $this.GetType()::AddYamlFormatting) {
+            return $this.GetType()::AddYamlFormatting($Metadata)
         }
 
         return $Metadata
@@ -28,10 +41,23 @@ class BaseHelpInfo {
         return $this.ToMetadataDictionary() | ConvertTo-Json -Depth 99
     }
 
+    [string] ToYaml() {
+        return $this.ToMetadataDictionary($true) | yayaml\ConvertTo-Yaml -Depth 99
+    }
+
     hidden static [void] AddToMetadataDictionary(
         [OrderedDictionary]$metadata,
         [string]$key,
         [string]$value
+    ) {
+        [BaseHelpInfo]::AddToMetadataDictionary($metadata, $key, $value, $false)
+    }
+
+    hidden static [void] AddToMetadataDictionary(
+        [OrderedDictionary]$metadata,
+        [string]$key,
+        [string]$value,
+        [bool]$AddYamlFormatting
     ) {
         if ([string]::isNullOrEmpty($value)) {
             $metadata.Add($key, '')
@@ -45,6 +71,15 @@ class BaseHelpInfo {
         [string]$key,
         [string[]]$values
     ) {
+        [BaseHelpInfo]::AddToMetadataDictionary($metadata, $key, $values, $false)
+    }
+
+    hidden static [void] AddToMetadataDictionary(
+        [OrderedDictionary]$metadata,
+        [string]$key,
+        [string[]]$values,
+        [bool]$AddYamlFormatting
+    ) {
         if ($values.Count -gt 0) {
             $metadata.Add($key, $values)
         } else {
@@ -56,6 +91,15 @@ class BaseHelpInfo {
         [OrderedDictionary]$metadata,
         [string]$key,
         [System.ValueType]$value
+    ) {
+        [BaseHelpInfo]::AddToMetadataDictionary($metadata, $key, $value, $false)
+    }
+
+    hidden static [void] AddToMetadataDictionary(
+        [OrderedDictionary]$metadata,
+        [string]$key,
+        [System.ValueType]$value,
+        [bool]$AddYamlFormatting
     ) {
         if ($null -eq $value) {
             $metadata.Add($key, $null)
@@ -69,6 +113,15 @@ class BaseHelpInfo {
         [string]$key,
         [System.ValueType[]]$values
     ) {
+        [BaseHelpInfo]::AddToMetadataDictionary($metadata, $key, $values, $false)
+    }
+
+    hidden static [void] AddToMetadataDictionary(
+        [OrderedDictionary]$metadata,
+        [string]$key,
+        [System.ValueType[]]$values,
+        [bool]$AddYamlFormatting
+    ) {
         if ($null -ne $values -and $values.Length -gt 0) {
             $metadata.Add($key, $values)
         } else {
@@ -81,8 +134,22 @@ class BaseHelpInfo {
         [string]$key,
         [BaseHelpInfo]$value
     ) {
+        [BaseHelpInfo]::AddToMetadataDictionary($metadata, $key, $value, $false)
+    }
+
+    hidden static [void] AddToMetadataDictionary(
+        [OrderedDictionary]$metadata,
+        [string]$key,
+        [BaseHelpInfo]$value,
+        [bool]$AddYamlFormatting
+    ) {
         if ($null -ne $value) {
-            $metadata.Add($key, $value.ToMetadataDictionary())
+            $dictionary = $value.ToMetadataDictionary($AddYamlFormatting)
+            if ($AddYamlFormatting -and $null -ne $value.GetType()::AddYamlFormatting) {
+                $metadata.Add($key, $value.GetType()::AddYamlFormatting($dictionary))
+            } else {
+                $metadata.Add($key, $dictionary)
+            }
         } else {
             $metadata.Add($key, [OrderedDictionary]::new([System.StringComparer]::OrdinalIgnoreCase))
         }
@@ -93,8 +160,25 @@ class BaseHelpInfo {
         [string]$key,
         [BaseHelpInfo[]]$values
     ) {
+        [BaseHelpInfo]::AddToMetadataDictionary($metadata, $key, $values, $false)
+    }
+
+    hidden static [void] AddToMetadataDictionary(
+        [OrderedDictionary]$metadata,
+        [string]$key,
+        [BaseHelpInfo[]]$values,
+        [bool]$AddYamlFormatting
+    ) {
         if ($null -ne $values -and $values.Length -gt 0) {
-            $metadata.Add($key, [OrderedDictionary[]]($values.ToMetadataDictionary()))
+            $dictionaries = @()
+            foreach ($value in $values) {
+                $dictionary = $value.ToMetadataDictionary($AddYamlFormatting)
+                if ($AddYamlFormatting -and $null -ne $value.GetType()::AddYamlFormatting) {
+                    $dictionary = $value.GetType()::AddYamlFormatting($dictionary)
+                }
+                $dictionaries += $dictionary
+            }
+            $metadata.Add($key, [OrderedDictionary[]]($dictionaries))
         } else {
             $metadata.Add($key, [OrderedDictionary[]]@())
         }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
@@ -16,13 +16,13 @@ using module ./ExampleHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -63,8 +63,7 @@ class ClassHelpInfo : BaseHelpInfo {
         $this.Initialize($astInfo, $registry)
     }
 
-    ClassHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+    ClassHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     hidden [void] Initialize([AstInfo]$astInfo, [DecoratingCommentsRegistry]$registry) {
         if ($null -eq $registry) {
@@ -72,14 +71,14 @@ class ClassHelpInfo : BaseHelpInfo {
         }
 
         $ClassAst = [ClassHelpInfo]::GetValidatedAst($astInfo)
-        $Help = $astInfo.DecoratingComment.ParsedValue
+        $Help     = $astInfo.DecoratingComment.ParsedValue
 
-        $this.Name = $ClassAst.Name.Trim()
-        $this.BaseTypes = $ClassAst.BaseTypes.ForEach({ Resolve-TypeName -TypeName -$_.TypeName })
-        $this.Attributes = [AttributeHelpInfo]::Resolve($astInfo)
-        $this.Properties = [ClassPropertyHelpInfo]::Resolve($astInfo, $registry)
+        $this.Name         = $ClassAst.Name.Trim()
+        $this.BaseTypes    = $ClassAst.BaseTypes.ForEach{ Resolve-TypeName -TypeName -$_.TypeName }
+        $this.Attributes   = [AttributeHelpInfo]::Resolve($astInfo)
+        $this.Properties   = [ClassPropertyHelpInfo]::Resolve($astInfo, $registry)
         $this.Constructors = [ConstructorOverloadHelpInfo]::Resolve($astInfo, $registry)
-        $this.Methods = [ClassMethodHelpInfo]::Resolve($astInfo, $registry)
+        $this.Methods      = [ClassMethodHelpInfo]::Resolve($astInfo, $registry)
 
         if ($Help.IsUsable()) {
             if ($HelpSynopsis = $Help.GetKeywordEntry('Synopsis')) {
@@ -121,8 +120,8 @@ class ClassHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
-        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Name        = $metadata.Name        | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
+        $metadata.Synopsis    = $metadata.Synopsis    | yayaml\Add-YamlFormat -ScalarStyle Folded  -PassThru
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
@@ -5,8 +5,8 @@ using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
 using module ../DecoratingComments/DecoratingCommentsRegistry.psm1
-using module ./BaseHelpInfo.psm1
 using module ./AttributeHelpInfo.psm1
+using module ./BaseHelpInfo.psm1
 using module ./ClassMethodHelpInfo.psm1
 using module ./ClassPropertyHelpInfo.psm1
 using module ./ConstructorOverloadHelpInfo.psm1

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
@@ -63,6 +63,9 @@ class ClassHelpInfo : BaseHelpInfo {
         $this.Initialize($astInfo, $registry)
     }
 
+    ClassHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
+
     hidden [void] Initialize([AstInfo]$astInfo, [DecoratingCommentsRegistry]$registry) {
         if ($null -eq $registry) {
             $registry = [DecoratingCommentsRegistry]::Get()

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassHelpInfo.psm1
@@ -116,4 +116,12 @@ class ClassHelpInfo : BaseHelpInfo {
 
         return $TargetAst
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
@@ -12,13 +12,13 @@ using module ./MethodOverloadHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -33,8 +33,7 @@ class ClassMethodHelpInfo : BaseHelpInfo {
 
     ClassMethodHelpInfo() {}
 
-    ClassMethodHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+    ClassMethodHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     ClassMethodHelpInfo(
         [string]$methodName,
@@ -42,6 +41,7 @@ class ClassMethodHelpInfo : BaseHelpInfo {
     ) {
         $this.Initialize($methodName, $classAstInfo, [DecoratingCommentsRegistry]::Get())
     }
+
     ClassMethodHelpInfo(
         [string]$methodName,
         [AstInfo]$classAstInfo,
@@ -49,12 +49,14 @@ class ClassMethodHelpInfo : BaseHelpInfo {
     ) {
         $this.Initialize($methodName, $classAstInfo, $registry)
     }
+
     ClassMethodHelpInfo(
         [string]$methodName,
         [TypeDefinitionAst]$classAst
     ) {
         $this.Initialize($methodName, $classAst, [DecoratingCommentsRegistry]::Get())
     }
+
     ClassMethodHelpInfo(
         [string]$methodName,
         [TypeDefinitionAst]$classAst,
@@ -85,7 +87,7 @@ class ClassMethodHelpInfo : BaseHelpInfo {
         if ($classAstInfo.Ast -isnot [TypeDefinitionAst]) {
             $Message = @(
                 'Invalid argument. [ClassMethodHelpInfo] expects an AstInfo object where'
-                "the Ast property is a TypeDefinitionAst that defines a class,"
+                'the Ast property is a TypeDefinitionAst that defines a class,'
                 "but the Ast property's type was $($classAstInfo.Ast.GetType().FullName)"
             ) -join ' '
             throw [System.ArgumentException]::new($Message, 'classAstInfo')
@@ -94,7 +96,6 @@ class ClassMethodHelpInfo : BaseHelpInfo {
             $registry = [DecoratingCommentsRegistry]::Get()
         }
 
-        [TypeDefinitionAst]$ClassAst = $classAstInfo.Ast
         $ClassHelp = $classAstInfo.DecoratingComment.ParsedValue
         $this.Name = $methodName
 
@@ -132,7 +133,7 @@ class ClassMethodHelpInfo : BaseHelpInfo {
         if ($classAstInfo.Ast -isnot [TypeDefinitionAst]) {
             $Message = @(
                 'Invalid argument. [ClassMethodHelpInfo]::Resolve()'
-                "expects an AstInfo object where the Ast property is a TypeDefinitionAst"
+                'expects an AstInfo object where the Ast property is a TypeDefinitionAst'
                 "that defines a class, but the Ast property's type was"
                 $classAstInfo.Ast.GetType().FullName
             ) -join ' '
@@ -156,7 +157,7 @@ class ClassMethodHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Name     = $metadata.Name     | yayaml\Add-YamlFormat -ScalarStyle Plain  -PassThru
         $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
 
         return $metadata

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
@@ -151,4 +151,11 @@ class ClassMethodHelpInfo : BaseHelpInfo {
                 [ClassMethodHelpInfo]::new($_, $classAstInfo, $registry)
             }
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
@@ -31,9 +31,40 @@ class ClassMethodHelpInfo : BaseHelpInfo {
     # The list of overloads for this method with their documentation.
     [MethodOverloadHelpInfo[]] $Overloads = @()
 
-    ClassMethodHelpInfo() {}
+    static ClassMethodHelpInfo() {
+        [ClassMethodHelpInfo]::InitializeFormatters()
+    }
 
-    ClassMethodHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
+    ClassMethodHelpInfo() {
+        <#
+            .SYNOPSIS
+            Default constructor. Doesn't initialize or define the instance.
+        #>
+    }
+
+    ClassMethodHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+        <#
+            .SYNOPSIS
+            Initializes an instance from a dictionary, as read back from YAML or JSON.
+
+            .PARAMETER metadata
+            The value for this parameter should be an ordered dictionary that keys with the same
+            name as this class's properties. The values for the `Name` and `Synopsis` keys should
+            be strings. The value for the `Overloads` key should be an array of ordered dictionaries
+            that can be used to initialize instances of the `MethodOverloadHelpInfo` class.
+
+            .EXAMPLE Convert YAML to an instance of ClassMethodHelpInfo
+            ```powershell
+            $classInfo   = Get-Content -Path .\ExampleClass.yaml -Raw | YaYaml\ConvertFrom-Yaml
+            $classMethod = [ClassMethodHelpInfo]::new($classInfo.Methods[0])
+            ```
+
+            .EXCEPTION System.Management.Automation.RuntimeException
+
+            This constructor throws an `InvalidOperation` runtime exception if the metadata
+            dictionary contains a key that doesn't match one of the class's properties.
+        #>
+    }
 
     ClassMethodHelpInfo(
         [string]$methodName,
@@ -161,5 +192,146 @@ class ClassMethodHelpInfo : BaseHelpInfo {
         $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
 
         return $metadata
+    }
+
+    static [HelpInfoFormatterDictionary] $Formatters
+
+    static [Void] InitializeFormatters() {
+        [ClassMethodHelpInfo]::InitializeFormatters($false, $false)
+    }
+
+    static [HelpInfoFormatterDictionary] InitializeFormatters([bool]$passThru, [bool]$force) {
+        if ($force -or [ClassMethodHelpInfo]::Formatters.Count -eq 0) {
+            [ClassMethodHelpInfo]::Formatters = [HelpInfoFormatterDictionary]::new(
+                [ordered]@{
+                    Block = [ClassMethodHelpInfo]::GetDefaultFormatter()
+                },
+                [ordered]@{
+                    Block = [ClassMethodHelpInfo]::GetDefaultSectionFormatter()
+                }
+            )
+        }
+
+        if ($passThru) {
+            return [ClassMethodHelpInfo]::Formatters
+        }
+
+        return $null
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [ClassMethodHelpInfo]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 3)]
+                    [int]
+                    $Level = 3,
+
+                    [switch]$IncludeHidden
+                )
+
+                if (-not $IncludeHidden -and $HelpInfo.IsHidden) {
+                    return ''
+                }
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder
+                | Add-Heading -Level $Level -Content $HelpInfo.Name
+                | Add-Line -Content $HelpInfo.Synopsis
+                | Add-Line -Content ''
+
+                $formatter = [MethodOverloadHelpInfo]::Formatters.Section.Block
+                $formatter.Parameters.Level = $Level + 1
+
+                $MarkdownBuilder
+                | Add-Line -Content (
+                    [MethodOverloadHelpInfo]::ToMarkdown(
+                        $HelpInfo.Overloads,
+                        $formatter
+                    ).TrimEnd()
+                )
+
+                return ($markdownBuilder.ToString() -replace '(\r?\n)+$', '$1')
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultSectionFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [ClassMethodHelpInfo[]]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [string]
+                    $Prefix,
+
+                    [ValidateRange(1, 4)]
+                    [int]
+                    $Level = 2,
+
+                    [string]
+                    $HeadingText = 'Methods'
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder | Add-Heading -Level $Level -Content $HeadingText
+
+                foreach ($method in $HelpInfo) {
+                    $formatter = [ClassMethodHelpInfo]::Formatters.Block
+                    $formatter.Parameters.Level = $Level + 1
+                    $formatted = $method.ToMarkdown($formatter)
+
+                    $MarkdownBuilder | Add-Line -Content $formatted
+                }
+
+                return ($MarkdownBuilder.ToString() -replace '(\r?\n)+$', '$1')
+            }
+        }
+    }
+
+    [string] ToMarkdown() {
+        return $this.ToMarkdown([ClassMethodHelpInfo]::Formatters.Default)
+    }
+
+    [string] ToMarkdown([HelpInfoFormatter]$formatter) {
+        return $formatter.Format($this)
+    }
+
+    static [string] ToMarkdown([ClassMethodHelpInfo[]]$values) {
+        return [ClassMethodHelpInfo]::ToMarkdown($values, [ClassMethodHelpInfo]::Formatters.Section.Default)
+    }
+
+    static [string] ToMarkdown([ClassMethodHelpInfo[]]$values, [HelpInfoFormatter]$formatter) {
+        return $formatter.FormatSection($values)
     }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassMethodHelpInfo.psm1
@@ -33,6 +33,9 @@ class ClassMethodHelpInfo : BaseHelpInfo {
 
     ClassMethodHelpInfo() {}
 
+    ClassMethodHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
+
     ClassMethodHelpInfo(
         [string]$methodName,
         [AstInfo]$classAstInfo

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
@@ -4,9 +4,10 @@
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
+using module ../DecoratingComments/DecoratingCommentsBlockParsed.psm1
 using module ../DecoratingComments/DecoratingCommentsRegistry.psm1
-using module ./BaseHelpInfo.psm1
 using module ./AttributeHelpInfo.psm1
+using module ./BaseHelpInfo.psm1
 
 #region    RequiredFunctions
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
@@ -49,6 +49,8 @@ class ClassPropertyHelpInfo : BaseHelpInfo {
     [string] $Description = ''
 
     ClassPropertyHelpInfo() {}
+    ClassPropertyHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
     ClassPropertyHelpInfo([AstInfo]$propertyAstInfo) {
         $this.Initialize(
             $propertyAstInfo,

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
@@ -13,14 +13,14 @@ using module ./BaseHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -50,14 +50,16 @@ class ClassPropertyHelpInfo : BaseHelpInfo {
     [string] $Description = ''
 
     ClassPropertyHelpInfo() {}
-    ClassPropertyHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+
+    ClassPropertyHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
+
     ClassPropertyHelpInfo([AstInfo]$propertyAstInfo) {
         $this.Initialize(
             $propertyAstInfo,
             [DecoratingCommentsBlockParsed]::new()
         )
     }
+
     ClassPropertyHelpInfo([AstInfo]$propertyAstInfo, [DecoratingCommentsBlockParsed]$classHelp) {
         $this.Initialize($propertyAstInfo, $classHelp)
     }
@@ -65,12 +67,12 @@ class ClassPropertyHelpInfo : BaseHelpInfo {
     hidden [void] Initialize([AstInfo]$astInfo, [DecoratingCommentsBlockParsed]$classHelp) {
         [PropertyMemberAst]$PropertyAst = [ClassPropertyHelpInfo]::GetValidatedAst($astInfo)
 
-        $PropertyName = $PropertyAst.Name.Trim()
-        $this.Name = $PropertyName
-        $this.Type = Resolve-TypeName -TypeName $PropertyAst.PropertyType.TypeName
+        $PropertyName    = $PropertyAst.Name.Trim()
+        $this.Name       = $PropertyName
+        $this.Type       = Resolve-TypeName -TypeName $PropertyAst.PropertyType.TypeName
         $this.Attributes = [AttributeHelpInfo]::Resolve($astInfo)
-        $this.IsHidden = $PropertyAst.IsHidden
-        $this.IsStatic = $PropertyAst.IsStatic
+        $this.IsHidden   = $PropertyAst.IsHidden
+        $this.IsStatic   = $PropertyAst.IsStatic
         if ($null -ne $PropertyAst.InitialValue) {
             $this.InitialValue = $PropertyAst.InitialValue.Extent.Text
         }
@@ -126,7 +128,7 @@ class ClassPropertyHelpInfo : BaseHelpInfo {
         if ($classAstInfo.Ast -isnot [TypeDefinitionAst]) {
             $Message = @(
                 'Invalid argument. [ClassPropertyHelpInfo]::Resolve()'
-                "expects an AstInfo object where the Ast property is a TypeDefinitionAst"
+                'expects an AstInfo object where the Ast property is a TypeDefinitionAst'
                 "that defines a class, but the Ast property's type was"
                 $classAstInfo.Ast.GetType().FullName
             ) -join ' '
@@ -159,9 +161,9 @@ class ClassPropertyHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
-        $metadata.Type = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
-        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Name        = $metadata.Name        | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
+        $metadata.Type        = $metadata.Type        | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
+        $metadata.Synopsis    = $metadata.Synopsis    | yayaml\Add-YamlFormat -ScalarStyle Folded  -PassThru
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ClassPropertyHelpInfo.psm1
@@ -154,4 +154,13 @@ class ClassPropertyHelpInfo : BaseHelpInfo {
             }
         }
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Type = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ConstructorOverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ConstructorOverloadHelpInfo.psm1
@@ -35,6 +35,8 @@ class ConstructorOverloadHelpInfo : OverloadHelpInfo {
     }
 
     ConstructorOverloadHelpInfo() : base() {}
+    ConstructorOverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     ConstructorOverloadHelpInfo(
         [AstInfo]$astInfo

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ConstructorOverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ConstructorOverloadHelpInfo.psm1
@@ -12,13 +12,13 @@ using module ./OverloadSignature.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -35,8 +35,8 @@ class ConstructorOverloadHelpInfo : OverloadHelpInfo {
     }
 
     ConstructorOverloadHelpInfo() : base() {}
-    ConstructorOverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+
+    ConstructorOverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     ConstructorOverloadHelpInfo(
         [AstInfo]$astInfo
@@ -63,7 +63,7 @@ class ConstructorOverloadHelpInfo : OverloadHelpInfo {
         if ($astInfo.Ast -isnot [TypeDefinitionAst]) {
             $Message = @(
                 'Invalid argument. [ConstructorOverloadHelpInfo]::Resolve()'
-                "expects an AstInfo object where the Ast property is a TypeDefinitionAst"
+                'expects an AstInfo object where the Ast property is a TypeDefinitionAst'
                 "that defines a class, but the Ast property's type was"
                 $astInfo.Ast.GetType().FullName
             ) -join ' '

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumHelpInfo.psm1
@@ -41,6 +41,8 @@ class EnumHelpInfo : BaseHelpInfo {
     [EnumValueHelpInfo[]] $Values = @()
 
     EnumHelpInfo() {}
+    EnumHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     EnumHelpInfo([AstInfo]$astInfo) {
         $this.Initialize($astInfo, [DecoratingCommentsRegistry]::Get())

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumHelpInfo.psm1
@@ -153,4 +153,13 @@ class EnumHelpInfo : BaseHelpInfo {
 
         return $TargetAst
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+        $metadata.Notes = $metadata.Notes | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumHelpInfo.psm1
@@ -13,13 +13,13 @@ using module ./ExampleHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -41,6 +41,7 @@ class EnumHelpInfo : BaseHelpInfo {
     [EnumValueHelpInfo[]] $Values = @()
 
     EnumHelpInfo() {}
+
     EnumHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
     }
 
@@ -58,9 +59,9 @@ class EnumHelpInfo : BaseHelpInfo {
         }
 
         $EnumAst = [EnumHelpInfo]::GetValidatedAst($astInfo)
-        $Help = $astInfo.DecoratingComment.ParsedValue
+        $Help    = $astInfo.DecoratingComment.ParsedValue
 
-        $this.Name = $EnumAst.Name
+        $this.Name        = $EnumAst.Name
         $this.IsFlagsEnum = [EnumHelpInfo]::TestIsFlagsEnum($EnumAst)
 
         if ($Help.IsUsable()) {
@@ -96,7 +97,6 @@ class EnumHelpInfo : BaseHelpInfo {
         }
 
         $ValuesAreFlags = [EnumHelpInfo]::TestIsFlagsEnum($enumAstInfo.Ast)
-
         $ValuesHelpInfo = [EnumValueHelpInfo]::Resolve($enumAstInfo, $registry)
 
         $NextValue = if ($ValuesAreFlags) { 1 } else { 0 }
@@ -157,10 +157,10 @@ class EnumHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
-        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Name        = $metadata.Name        | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
+        $metadata.Synopsis    = $metadata.Synopsis    | yayaml\Add-YamlFormat -ScalarStyle Folded  -PassThru
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
-        $metadata.Notes = $metadata.Notes | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+        $metadata.Notes       = $metadata.Notes       | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata
     }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
@@ -142,4 +142,11 @@ class EnumValueHelpInfo : BaseHelpInfo {
             }
         }
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Label = $metadata.Label | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
@@ -52,6 +52,8 @@ class EnumValueHelpInfo : BaseHelpInfo {
         $this.Description = ''
         $this.HasExplicitValue = $false
     }
+    EnumValueHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     EnumValueHelpInfo([AstInfo]$astInfo) {
         $this.Initialize($astInfo, [DecoratingCommentsBlockParsed]::new())

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
@@ -12,13 +12,13 @@ using module ./BaseHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -69,8 +69,8 @@ class EnumValueHelpInfo : BaseHelpInfo {
         $this.Description = ''
         $this.HasExplicitValue = $false
     }
-    EnumValueHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+
+    EnumValueHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     EnumValueHelpInfo([AstInfo]$astInfo) {
         $this.Initialize($astInfo, [DecoratingCommentsBlockParsed]::new())
@@ -82,10 +82,10 @@ class EnumValueHelpInfo : BaseHelpInfo {
 
     hidden [void] Initialize([AstInfo]$astInfo, [DecoratingCommentsBlockParsed]$enumHelp) {
         [MemberAst]$EnumValueAst = [EnumValueHelpInfo]::GetValidatedAst($astInfo)
-        $LabelName = $EnumValueAst.Name.Trim()
-        $this.Label = $LabelName
-        $this.Value = $EnumValueAst.InitialValue.Value
-        $this.HasExplicitValue = $null -ne $EnumValueAst.InitialValue
+        $LabelName               = $EnumValueAst.Name.Trim()
+        $this.Label              = $LabelName
+        $this.Value              = $EnumValueAst.InitialValue.Value
+        $this.HasExplicitValue   = $null -ne $EnumValueAst.InitialValue
         if ($null -ne $enumHelp -and $enumHelp.IsUsable()) {
             $LabelDescription = $enumHelp.GetKeywordEntry('Label', $LabelName)
             if (-not [string]::IsNullOrEmpty($LabelDescription)) {
@@ -130,7 +130,7 @@ class EnumValueHelpInfo : BaseHelpInfo {
         if ($enumAstInfo.Ast -isnot [TypeDefinitionAst]) {
             $Message = @(
                 'Invalid argument. [EnumValueHelpInfo]::Resolve()'
-                "expects an AstInfo object where the Ast property is a TypeDefinitionAst"
+                'expects an AstInfo object where the Ast property is a TypeDefinitionAst'
                 "that defines a enum, but the Ast property's type was"
                 $enumAstInfo.Ast.GetType().FullName
             ) -join ' '
@@ -163,7 +163,7 @@ class EnumValueHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Label = $metadata.Label | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Label       = $metadata.Label       | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/EnumValueHelpInfo.psm1
@@ -4,7 +4,24 @@
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
+using module ../DecoratingComments/DecoratingCommentsBlockParsed.psm1
+using module ../DecoratingComments/DecoratingCommentsRegistry.psm1
 using module ./BaseHelpInfo.psm1
+
+#region    RequiredFunctions
+
+$SourceFolder = $PSScriptRoot
+while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
+  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+}
+$RequiredFunctions = @(
+  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+)
+foreach ($RequiredFunction in $RequiredFunctions) {
+  . $RequiredFunction
+}
+
+#endregion RequiredFunctions
 
 class EnumValueHelpInfo : BaseHelpInfo {
     # The value's label.

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
@@ -39,4 +39,11 @@ class ExampleHelpInfo : BaseHelpInfo {
             }
         }
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Title = $metadata.Title | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Body = $metadata.Body | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
@@ -12,6 +12,10 @@ class ExampleHelpInfo : BaseHelpInfo {
     # The body text for the example.
     [string] $Body
 
+    ExampleHelpInfo() {}
+    ExampleHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
+
     static [ExampleHelpInfo[]] Resolve ([DecoratingCommentsBlockParsed]$help) {
         if ((-not $help.IsUsable()) -or ($help.Example.Count -eq 0)) {
             return @()

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
@@ -6,6 +6,7 @@ using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
 using module ../DecoratingComments/DecoratingCommentsBlockParsed.psm1
 using module ./BaseHelpInfo.psm1
+using module ./HelpInfoFormatter.psm1
 
 class ExampleHelpInfo : BaseHelpInfo {
     # The title for the example.
@@ -14,7 +15,12 @@ class ExampleHelpInfo : BaseHelpInfo {
     [string] $Body
 
     ExampleHelpInfo() {}
+
     ExampleHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
+
+    static ExampleHelpInfo() {
+        [ExampleHelpInfo]::InitializeFormatters()
     }
 
     static [ExampleHelpInfo[]] Resolve ([DecoratingCommentsBlockParsed]$help) {
@@ -36,7 +42,7 @@ class ExampleHelpInfo : BaseHelpInfo {
         if ((-not $help.IsUsable()) -or ($help.Example.Count -eq 0)) {
             return @()
         }
-        
+
         return $help.Example | ForEach-Object -Process {
             [ExampleHelpInfo]@{
                 Title = $_.Value
@@ -46,9 +52,235 @@ class ExampleHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Title = $metadata.Title | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
-        $metadata.Body = $metadata.Body | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+        $metadata.Title = $metadata.Title | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
+        $metadata.Body  = $metadata.Body  | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata
+    }
+
+
+    static [HelpInfoFormatterDictionary] $Formatters
+
+    static InitializeFormatters() {
+        [ExampleHelpInfo]::InitializeFormatters($false, $false)
+    }
+
+    static [HelpInfoFormatterDictionary] InitializeFormatters([bool]$passThru, [bool]$force) {
+        if ($force -or [ExampleHelpInfo]::Formatters.Count -eq 0) {
+            [ExampleHelpInfo]::Formatters = [HelpInfoFormatterDictionary]::new(
+                [ordered]@{
+                    Block    = [ExampleHelpInfo]::GetDefaultFormatter()
+                    ListItem = [ExampleHelpInfo]::GetListItemFormatter()
+                },
+                [ordered]@{
+                    Block = [ExampleHelpInfo]::GetDefaultSectionFormatter()
+                    List  = [ExampleHelpInfo]::GetListSectionFormatter()
+                }
+            )
+        }
+
+        if ($passThru) {
+            return [ExampleHelpInfo]::Formatters
+        }
+
+        return $null
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [cmdletbinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [ExampleHelpInfo]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [string]
+                    $Prefix,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 3
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder | Add-Heading -Level $Level -Content (
+                    ($Prefix, $HelpInfo.Title -join ' ').Trim()
+                )
+
+                $splitLines = $HelpInfo.Body.Trim() -split '\r?\n'
+                foreach ($line in $splitLines) {
+                    $MarkdownBuilder | Add-Line -Content $Line
+                }
+
+                return $MarkdownBuilder.ToString()
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetListItemFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [ExampleHelpInfo]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 3
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $title = ($Prefix, $HelpInfo.Title -join ' ').Trim()
+
+                if (![string]::IsNullOrEmpty($title)) {
+                    $MarkdownBuilder | Add-Line -Content $title | Add-Line
+                }
+
+                $MarkdownBuilder | Add-Line -Content $HelpInfo.Body
+
+                return $MarkdownBuilder.ToString()
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultSectionFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{ }
+            ScriptBlock = {
+                [cmdletbinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [ExampleHelpInfo[]]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [string]
+                    $Prefix,
+
+                    [ValidateRange(1, 5)]
+                    [int]
+                    $Level = 2
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $markdownBuilder | Add-Heading -Level $Level -Content 'Examples'
+
+                $Count = 1
+                foreach ($Example in $HelpInfo) {
+                    $formatter = [ExampleHelpInfo]::Formatters.Default
+
+                    $formatter.Parameters.Prefix = if ([string]::IsNullOrEmpty($Example.Title)) {
+                        "Example ${Count}"
+                    } else {
+                        "Example ${Count}:"
+                    }
+                    $formatter.Parameters.Level  = $Level + 1
+
+                    $markdownBuilder | Add-Line -Content $Example.ToMarkdown($formatter)
+
+                    $Count++
+                }
+
+                return $markdownBuilder.ToString()
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetListSectionFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [ExampleHelpInfo[]]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [string]
+                    $Prefix,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 2,
+
+                    [string]
+                    $HeadingText = 'Examples'
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder |
+                    Add-Heading -Level $Level -Content $HeadingText |
+                    Start-List -AsNumberedList
+
+                foreach ($param in $HelpInfo) {
+                    $formatter = [ExampleHelpInfo]::Formatters.ListItem
+                    $formatted = $param.ToMarkdown($formatter)
+
+                    $MarkdownBuilder | Add-ListItem -ListItem $formatted
+                }
+
+                $MarkdownBuilder.EndList().ToString()
+            }
+        }
+    }
+
+    [string] ToMarkdown() {
+        return $this.ToMarkdown([ExampleHelpInfo]::Formatters.Default)
+    }
+
+    [string] ToMarkdown([HelpInfoFormatter]$formatter) {
+        return $formatter.Format($this)
+    }
+
+    static [string] ToMarkdown([ExampleHelpInfo[]]$examples) {
+        return [ExampleHelpInfo]::ToMarkdown($examples, [ExampleHelpInfo]::Formatters.Section.Default)
+    }
+
+    static [string] ToMarkdown([ExampleHelpInfo[]]$examples, [HelpInfoFormatter]$formatter) {
+        return $formatter.FormatSection($examples)
     }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/ExampleHelpInfo.psm1
@@ -4,6 +4,7 @@
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
+using module ../DecoratingComments/DecoratingCommentsBlockParsed.psm1
 using module ./BaseHelpInfo.psm1
 
 class ExampleHelpInfo : BaseHelpInfo {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/HelpInfoFormatter.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/HelpInfoFormatter.psm1
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ./BaseHelpInfo.psm1
+
+class HelpInfoFormatter {
+    [scriptblock]
+    $ScriptBlock = {
+        param (
+            [BaseHelpInfo] $helpInfo
+        )
+
+        throw 'HelpInfoFormmater.ScriptBlock must be defined.'
+    }
+
+    [hashtable]
+    $Parameters  = @{}
+
+    HelpInfoFormatter() {}
+
+    HelpInfoFormatter([scriptblock]$scriptBlock) {
+        $this.ScriptBlock = $scriptBlock
+    }
+
+    [void] ValidateScriptBlock() {
+        <#
+        .SYNOPSIS
+            Validates the script block for the HelpInfoFormatter.
+        .DESCRIPTION
+            Validates the script block for the HelpInfoFormatter. Every formatter must define a
+            script block. The scriptblock must have a parameter named `HelpInfo` that accepts
+            the object to format. It may have other parameters, but `HelpInfo` is required.
+        .EXCEPTION System.MissingMemberException
+            Thrown if the script block is not defined for the formatter.
+        .EXCEPTION System.Management.Automation.ParameterBindingException
+            Thrown if the script block does not have a parameter named `HelpInfo`.
+        #>
+        if ($null -eq $this.ScriptBlock) {
+            throw [System.MissingMemberException]::new(
+                'HelpInfoFormatter.ScriptBlock must be defined.'
+            )
+        }
+
+        $DefinedParameters = $this.ScriptBlock.Ast.ParamBlock.Parameters.ForEach{
+            $_.Name.ToString()
+        }
+
+        if ('$HelpInfo' -notin $DefinedParameters) {
+            $Message = @(
+                "Invalid HelpInfoFormatter.ScriptBlock: missing parameter 'HelpInfo'."
+                "The 'HelpInfo' parameter passes the object to format."
+            ) -join ' '
+            throw [System.Management.Automation.ParameterBindingException]::new($Message)
+        }
+    }
+
+    [string] Format([BaseHelpInfo]$helpInfo) {
+        $this.ValidateScriptBlock()
+
+        $this.Parameters['HelpInfo'] = $helpInfo
+        $ParametersHash              = $this.Parameters
+
+        return (& $this.ScriptBlock @ParametersHash)
+    }
+
+    static [string] Format([HelpInfoFormatter]$formatter, [BaseHelpInfo]$helpInfo) {
+        return $formatter.Format($helpInfo)
+    }
+
+    [string] FormatSection([BaseHelpInfo[]]$helpInfo) {
+        $this.ValidateScriptBlock()
+
+        $this.Parameters['HelpInfo'] = $helpInfo
+        $ParametersHash              = $this.Parameters
+
+        return (& $this.ScriptBlock @ParametersHash)
+    }
+
+    static [string] FormatSection([HelpInfoFormatter]$formatter, [BaseHelpInfo[]]$helpInfo) {
+        return $formatter.Format($helpInfo)
+    }
+}

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/HelpInfoFormatterDictionary.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/HelpInfoFormatterDictionary.psm1
@@ -1,0 +1,186 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+using module ./HelpInfoFormatter.psm1
+
+class HelpInfoFormatterDictionary : System.Collections.Specialized.OrderedDictionary {
+    <#
+        .SYNOPSIS
+            A dictionary of HelpInfoFormatter definitions to use when formatting help info.
+    #>
+
+    HelpInfoFormatterDictionary() : base([System.StringComparer]::OrdinalIgnoreCase) {
+        <#
+            .SYNOPSIS
+                Creates a new instance without any formatters. The dictionary isn't case sensitive.
+        #>
+    }
+    HelpInfoFormatterDictionary([System.StringComparer]$comparer) : base($comparer) {
+        <#
+            .SYNOPSIS
+                Creates a new instance without any formatters. The dictionary uses the specified
+                comparer for keys.
+        #>
+    }
+
+    HelpInfoFormatterDictionary(
+        [HelpInfoFormatter]$defaultFormatter
+    ) : base([System.StringComparer]::OrdinalIgnoreCase) {
+        <#
+            .SYNOPSIS
+                Creates a new instance with a default formatter.
+
+            .DESCRIPTION
+                Defines the dictionary with a default formatter. The dictionary isn't case
+                sensitive.
+            
+            .PARAMETER defaultFormatter
+                The default formatter to use when formatting help info.
+        #>
+
+        $this.Add('Default', $defaultFormatter)
+    }
+
+    HelpInfoFormatterDictionary(
+        [HelpInfoFormatter]$defaultFormatter,
+        [HelpInfoFormatter]$defaultSectionFormatter
+    ) : base([System.StringComparer]::OrdinalIgnoreCase) {
+        <#
+            .SYNOPSIS
+                Creates a new instance with a default formatter and a default section formatter.
+
+            .DESCRIPTION
+                Defines the dictionary with a default formatter and a default section formatter.
+                The dictionary isn't case sensitive. The section formatter is used when formatting
+                a group of the same `HelpInfo` type, such as a group of `ParameterHelpInfo` or
+                `ExampleHelpInfo` objects.
+            
+            .PARAMETER defaultFormatter
+                The default formatter to use when formatting a single instance.
+            
+            .PARAMETER defaultSectionFormatter
+                The default formatter to use when formatting a group of instances.
+        #>
+
+        $this.Add('Default', $defaultFormatter)
+        $this.Add('Section', [ordered]@{
+            'Default' = $defaultSectionFormatter
+        })
+    }
+
+    HelpInfoFormatterDictionary(
+        [System.Collections.Specialized.OrderedDictionary]$formatters
+    ) : base([System.StringComparer]::OrdinalIgnoreCase) {
+        <#
+            .SYNOPSIS
+                Creates a new instance with the specified formatters.
+
+            .DESCRIPTION
+                Defines the dictionary with the specified formatters. The dictionary isn't case
+                sensitive.
+            
+            .PARAMETER formatters
+                The formatters to use when formatting help info. Must be an ordered dictionary. If
+                the dictionary doesn't contain a key named `Default`, the first formatter is used
+                as the default formatter.
+        #>
+
+        [HelpInfoFormatterDictionary]::AddFormatters($this, $formatters)
+    }
+
+    HelpInfoFormatterDictionary(
+        [System.Collections.Specialized.OrderedDictionary]$formatters,
+        [System.Collections.Specialized.OrderedDictionary]$sectionFormatters
+    ) : base([System.StringComparer]::OrdinalIgnoreCase) {
+        <#
+            .SYNOPSIS
+                Creates a new instance with the specified formatters and section formatters.
+
+            .DESCRIPTION
+                Defines the dictionary with the specified formatters and section formatters. The
+                dictionary isn't case sensitive. The section formatters are used when formatting
+                a group of the same `HelpInfo` type, such as a group of `ParameterHelpInfo` or
+                `ExampleHelpInfo` objects.
+            
+            .PARAMETER formatters
+                The formatters to use when formatting a single instance. Must be an ordered
+                dictionary. If the dictionary doesn't contain a key named `Default`, the first
+                formatter is used as the default formatter.
+            
+            .PARAMETER sectionFormatters
+                The formatters to use when formatting a group of instances. Must be an ordered
+                dictionary. If the dictionary doesn't contain a key named `Default`, the first
+                formatter is used as the default formatter.
+        #>
+
+        $this.Section = [System.Collections.Specialized.OrderedDictionary]::new()
+
+        [HelpInfoFormatterDictionary]::AddFormatters($this, $formatters)
+        [HelpInfoFormatterDictionary]::AddFormatters($this.Section, $sectionFormatters)
+    }
+
+    static hidden AddFormatters(
+        [System.Collections.Specialized.OrderedDictionary]$dictionary,
+        [System.Collections.Specialized.OrderedDictionary]$formatters
+    ) {
+        <#
+            .SYNOPSIS
+                Adds the specified formatters to the specified dictionary.
+
+            .DESCRIPTION
+                Adds the specified formatters to the specified dictionary. If the dictionary
+                doesn't contain a key named `Default`, the first formatter is used as the default
+                formatter.
+            
+            .PARAMETER dictionary
+                The dictionary to add the formatters to. Typically either the
+                HelpInfoFormatterDictionary itself or the `Section` key of the dictionary.
+            
+            .PARAMETER formatters
+                The formatters to add to the dictionary. Must be an ordered dictionary. Every key
+                must be a string, every value must be a `HelpInfoFormatter` object. If the
+                dictionary doesn't contain a key named `Default`, the first formatter is used as
+                the default formatter.
+        #>
+
+        if ($null -ne $formatters.Default) {
+            [HelpInfoFormatterDictionary]::ValidateValue($formatters.Default)
+            $dictionary.Add('Default', $formatters.Default)
+        }
+        foreach ($formatter in $formatters.Keys.Where{ $_ -ne 'Default' }) {
+            [HelpInfoFormatterDictionary]::ValidateKeyValue(
+                $formatter,
+                $formatters[$formatter]
+            )
+
+            if ($null -eq $dictionary.Default) {
+                $dictionary.Add('Default', $formatters[$formatter])
+            }
+
+            $dictionary.Add($formatter, $formatters[$formatter])
+        }
+    }
+
+    hidden static ValidateValue([object]$value) {
+        if ($value -isnot [HelpInfoFormatter]) {
+            throw [System.ArgumentException]::new(
+                'The values must be of type HelpInfoFormatter.'
+            )
+        }
+    }
+
+    hidden static ValidateKeyValue([object]$key, [object]$value) {
+        if ($key -isnot [string]) {
+            throw [System.ArgumentException]::new(
+                'The keys must be strings.'
+            )
+        }
+        if ($key -eq 'Section') {
+            throw [System.ArgumentException]::new(
+                "The key 'Section' is reserved and cannot be used."
+            )
+        }
+
+        [HelpInfoFormatterDictionary]::ValidateValue($value)
+    }
+}

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/MethodOverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/MethodOverloadHelpInfo.psm1
@@ -106,4 +106,12 @@ class MethodOverloadHelpInfo : OverloadHelpInfo {
             [MethodOverloadHelpInfo]::new($MethodAstInfo)
         }
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata = [OverloadHelpInfo]::AddYamlFormatting($metadata)
+
+        $metadata.ReturnType = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/MethodOverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/MethodOverloadHelpInfo.psm1
@@ -11,14 +11,14 @@ using module ./OverloadHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -36,8 +36,8 @@ class MethodOverloadHelpInfo : OverloadHelpInfo {
     [bool] $IsStatic = $false
 
     MethodOverloadHelpInfo() : base() {}
-    MethodOverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+
+    MethodOverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     MethodOverloadHelpInfo(
         [AstInfo]$astInfo
@@ -69,7 +69,7 @@ class MethodOverloadHelpInfo : OverloadHelpInfo {
 
     hidden [void] SetProperties([FunctionMemberAst]$methodAst) {
         $this.ReturnType = Resolve-TypeName -TypeName $methodAst.ReturnType.TypeName
-        $this.IsStatic = $methodAst.IsStatic
+        $this.IsStatic   = $methodAst.IsStatic
     }
 
     static [MethodOverloadHelpInfo[]] Resolve(
@@ -80,7 +80,7 @@ class MethodOverloadHelpInfo : OverloadHelpInfo {
         if ($astInfo.Ast -isnot [TypeDefinitionAst]) {
             $Message = @(
                 'Invalid argument. [MethodOverloadHelpInfo]::Resolve()'
-                "expects an AstInfo object where the Ast property is a TypeDefinitionAst"
+                'expects an AstInfo object where the Ast property is a TypeDefinitionAst'
                 "that defines a class, but the Ast property's type was"
                 $astInfo.Ast.GetType().FullName
             ) -join ' '

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/MethodOverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/MethodOverloadHelpInfo.psm1
@@ -36,6 +36,8 @@ class MethodOverloadHelpInfo : OverloadHelpInfo {
     [bool] $IsStatic = $false
 
     MethodOverloadHelpInfo() : base() {}
+    MethodOverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     MethodOverloadHelpInfo(
         [AstInfo]$astInfo

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
@@ -53,4 +53,11 @@ class OverloadExceptionHelpInfo : BaseHelpInfo {
             [OverloadExceptionHelpInfo]::new($_.Value, $_.Content)
         }
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Type = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
@@ -25,6 +25,10 @@ class OverloadExceptionHelpInfo : BaseHelpInfo {
         $this.Initialize($type, $description)
     }
 
+    static OverloadExceptionHelpInfo () {
+        [OverloadExceptionHelpInfo]::InitializeFormatters()
+    }
+
     hidden [void] Initialize([string]$type, [string]$description) {
         $this.Type = $type
         $this.Description = $description
@@ -47,7 +51,7 @@ class OverloadExceptionHelpInfo : BaseHelpInfo {
 
     static [OverloadExceptionHelpInfo[]] Resolve([DecoratingCommentsBlockParsed]$overloadHelp) {
         $Exceptions = $overloadHelp.Exception
-        
+
         if ($null -eq $Exceptions) {
             return @()
         }
@@ -62,5 +66,229 @@ class OverloadExceptionHelpInfo : BaseHelpInfo {
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata
+    }
+
+    static [HelpInfoFormatterDictionary] $Formatters
+
+    static InitializeFormatters() {
+        [OverloadExceptionHelpInfo]::InitializeFormatters($false, $false)
+    }
+
+    static [HelpInfoFormatterDictionary] InitializeFormatters([bool]$passThru, [bool]$force) {
+        if ($force -or [OverloadExceptionHelpInfo]::Formatters.Count -eq 0) {
+            [OverloadExceptionHelpInfo]::Formatters = [HelpInfoFormatterDictionary]::new(
+                [ordered]@{
+                    Block    = [OverloadExceptionHelpInfo]::GetDefaultFormatter()
+                    ListItem = [OverloadExceptionHelpInfo]::GetListItemFormatter()
+                },
+                [ordered]@{
+                    Block = [OverloadExceptionHelpInfo]::GetDefaultSectionFormatter()
+                    List  = [OverloadExceptionHelpInfo]::GetListSectionFormatter()
+                }
+            )
+        }
+
+        if ($passThru) {
+            return [OverloadExceptionHelpInfo]::Formatters
+        }
+
+        return $null
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadExceptionHelpInfo]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 4
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder
+                | Add-Heading -Level $Level -Content $HelpInfo.Type
+
+                $Description = $HelpInfo.Description
+                if ([string]::IsNullOrEmpty($Description)) {
+                    $Description = '<!-- TODO: Add a description. -->'
+                }
+
+                if (-not [string]::IsNullOrEmpty($HelpInfo.Description)) {
+                    $lines = $Description -split '\r?\n'
+                    foreach ($line in $lines) {
+                        $MarkdownBuilder | Add-Line -Content $line
+                    }
+                }
+
+                return $MarkdownBuilder.ToString()
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetListItemFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadExceptionHelpInfo]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 4
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $Title = '**{0}**' -f $HelpInfo.Type
+
+                $Description = $HelpInfo.Description
+                if ([string]::IsNullOrEmpty($Description)) {
+                    $Description = '<!-- TODO: Add a description. -->'
+                }
+
+                $MarkdownBuilder |
+                    Add-Line -Content $Title |
+                    Add-Line |
+                    Add-Line -Content $Description
+
+                return $MarkdownBuilder.ToString()
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultSectionFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadExceptionHelpInfo[]]
+                    $HelpInfo,
+
+                    [string]
+                    $Prefix,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 3
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder
+                | Add-Heading -Level $Level -Content 'Exceptions'
+
+                foreach ($Exception in $HelpInfo) {
+                    $formatter = [OverloadExceptionHelpInfo]::Formatters.Default
+                    $formatter.Parameters.Level = $Level + 1
+
+                    $markdownBuilder | Add-Line -Content $Exception.ToMarkdown($formatter)
+                }
+
+                return ($markdownBuilder.ToString() -replace '(\r?\n)+$', '$1')
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetListSectionFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadExceptionHelpInfo[]]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [string]
+                    $Prefix,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 5,
+
+                    [string]
+                    $HeadingText = 'Exceptions'
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder |
+                    Add-Heading -Level $Level -Content $HeadingText |
+                    Start-List
+
+                foreach ($param in $HelpInfo) {
+                    $formatter = [OverloadExceptionHelpInfo]::Formatters.ListItem
+                    $formatted = $param.ToMarkdown($formatter)
+
+                    $MarkdownBuilder | Add-ListItem -ListItem $formatted
+                }
+
+                $MarkdownBuilder.EndList().ToString()
+            }
+        }
+    }
+
+    [string] ToMarkdown() {
+        return $this.ToMarkdown([OverloadExceptionHelpInfo]::Formatters.Default)
+    }
+
+    [string] ToMarkdown([HelpInfoFormatter]$formatter) {
+        return $formatter.Format($this)
+    }
+
+    static [string] ToMarkdown([OverloadExceptionHelpInfo[]]$values) {
+        return [OverloadExceptionHelpInfo]::ToMarkdown($values, [OverloadExceptionHelpInfo]::Formatters.Section.Default)
+    }
+
+    static [string] ToMarkdown([OverloadExceptionHelpInfo[]]$values, [HelpInfoFormatter]$formatter) {
+        return $formatter.FormatSection($values)
     }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
@@ -4,6 +4,7 @@
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
+using module ../DecoratingComments/DecoratingCommentsBlockParsed.psm1
 using module ./BaseHelpInfo.psm1
 
 class OverloadExceptionHelpInfo : BaseHelpInfo {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadExceptionHelpInfo.psm1
@@ -13,6 +13,8 @@ class OverloadExceptionHelpInfo : BaseHelpInfo {
     [string] $Description = ''
 
     OverloadExceptionHelpInfo() {}
+    OverloadExceptionHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     OverloadExceptionHelpInfo([string]$type) {
         $this.Initialize($type, '')

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
@@ -119,4 +119,11 @@ class OverloadHelpInfo : BaseHelpInfo {
 
         return $TargetAst
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
@@ -49,6 +49,8 @@ class OverloadHelpInfo : BaseHelpInfo {
     [OverloadExceptionHelpInfo[]] $Exceptions = @()
 
     OverloadHelpInfo() {}
+    OverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     OverloadHelpInfo([AstInfo]$astInfo) {
         $this.Initialize($astInfo, [DecoratingCommentsRegistry]::Get())

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
@@ -5,8 +5,8 @@ using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
 using module ../DecoratingComments/DecoratingCommentsRegistry.psm1
-using module ./BaseHelpInfo.psm1
 using module ./AttributeHelpInfo.psm1
+using module ./BaseHelpInfo.psm1
 using module ./ExampleHelpInfo.psm1
 using module ./OverloadExceptionHelpInfo.psm1
 using module ./OverloadParameterHelpInfo.psm1

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadHelpInfo.psm1
@@ -16,13 +16,13 @@ using module ./OverloadSignature.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -49,8 +49,8 @@ class OverloadHelpInfo : BaseHelpInfo {
     [OverloadExceptionHelpInfo[]] $Exceptions = @()
 
     OverloadHelpInfo() {}
-    OverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+
+    OverloadHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     OverloadHelpInfo([AstInfo]$astInfo) {
         $this.Initialize($astInfo, [DecoratingCommentsRegistry]::Get())
@@ -63,6 +63,7 @@ class OverloadHelpInfo : BaseHelpInfo {
     OverloadHelpInfo([FunctionMemberAst]$targetAst) {
         $this.Initialize($targetAst, [DecoratingCommentsRegistry]::Get())
     }
+
     OverloadHelpInfo([FunctionMemberAst]$targetAst, $registry) {
         $this.Initialize($targetAst, $registry)
     }
@@ -123,7 +124,7 @@ class OverloadHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Synopsis = $metadata.Synopsis | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Synopsis    = $metadata.Synopsis    | yayaml\Add-YamlFormat -ScalarStyle Folded  -PassThru
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
@@ -12,14 +12,14 @@ using module ./BaseHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -33,8 +33,8 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
     [string] $Description = ''
 
     OverloadParameterHelpInfo() {}
-    OverloadParameterHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
-    }
+
+    OverloadParameterHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
 
     OverloadParameterHelpInfo([AstInfo]$parameterAstInfo) {
         $this.Initialize(
@@ -43,7 +43,10 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
         )
     }
 
-    OverloadParameterHelpInfo([AstInfo]$parameterAstInfo, [DecoratingCommentsBlockParsed]$overloadHelp) {
+    OverloadParameterHelpInfo(
+        [AstInfo]$parameterAstInfo,
+        [DecoratingCommentsBlockParsed]$overloadHelp
+    ) {
         $this.Initialize($parameterAstInfo, $overloadHelp)
     }
 
@@ -54,15 +57,23 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
         )
     }
 
-    OverloadParameterHelpInfo([ParameterAst]$parameterAst, [DecoratingCommentsBlockParsed]$overloadHelp) {
+    OverloadParameterHelpInfo(
+        [ParameterAst]$parameterAst,
+        [DecoratingCommentsBlockParsed]$overloadHelp
+    ) {
         $this.Initialize($parameterAst, $overloadHelp)
     }
 
-    hidden [void] Initialize([AstInfo]$parameterAstInfo, [DecoratingCommentsBlockParsed]$overloadHelp) {
-        [ParameterAst]$ParameterAst = [OverloadParameterHelpInfo]::GetValidatedAst($parameterAstInfo)
+    hidden [void] Initialize(
+        [AstInfo]$parameterAstInfo,
+        [DecoratingCommentsBlockParsed]$overloadHelp
+    ) {
+        [ParameterAst]$ParameterAst = [OverloadParameterHelpInfo]::GetValidatedAst(
+            $parameterAstInfo
+        )
         $ParameterName = $ParameterAst.Name.VariablePath.ToString()
         $ParameterType = $ParameterAst.StaticType.FullName
-        $this.Name = $ParameterName
+        $this.Name     = $ParameterName
         # For custom types the parser doesn't know about, they're listed as
         # an attribute instead. We should use that as the type name if
         # available.
@@ -88,10 +99,13 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
         }
     }
 
-    hidden [void] Initialize([ParameterAst]$parameterAst, [DecoratingCommentsBlockParsed]$overloadHelp) {
+    hidden [void] Initialize(
+        [ParameterAst]$parameterAst,
+        [DecoratingCommentsBlockParsed]$overloadHelp
+    ) {
         $ParameterName = $parameterAst.Name.VariablePath.ToString()
         $ParameterType = $parameterAst.StaticType.FullName
-        $this.Name = $ParameterName
+        $this.Name     = $ParameterName
         # For custom types the parser doesn't know about, they're listed as
         # an attribute instead. We should use that as the type name if
         # available.
@@ -129,9 +143,9 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
     ) {
         if ($overloadAstInfo.Ast -isnot [FunctionMemberAst]) {
             $Message = @(
-                "The [OverloadParameterHelpInfo]::Resolve() method expects an AstInfo object"
-                "where the Ast property is a FunctionMemberAst,"
-                "but received an AstInfo object with an Ast type of"
+                'The [OverloadParameterHelpInfo]::Resolve() method expects an AstInfo object'
+                'where the Ast property is a FunctionMemberAst,'
+                'but received an AstInfo object with an Ast type of'
                 $overloadAstInfo.Ast.GetType().FullName
             ) -join ' '
             throw $Message
@@ -142,7 +156,10 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
         }
         $OverloadHelp = $overloadAstInfo.DecoratingComment.ParsedValue
 
-        $ParameterInfo = [OverloadParameterHelpInfo]::GetParametersAstInfo($overloadAstInfo, $registry)
+        $ParameterInfo = [OverloadParameterHelpInfo]::GetParametersAstInfo(
+            $overloadAstInfo,
+            $registry
+        )
 
         if ($ParameterInfo.Count -eq 0) {
             return @()
@@ -177,8 +194,8 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
-        $metadata.Type = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Name        = $metadata.Name        | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
+        $metadata.Type        = $metadata.Type        | yayaml\Add-YamlFormat -ScalarStyle Plain   -PassThru
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
@@ -32,6 +32,8 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
     [string] $Description = ''
 
     OverloadParameterHelpInfo() {}
+    OverloadParameterHelpInfo([OrderedDictionary]$metadata) : base($metadata) {
+    }
 
     OverloadParameterHelpInfo([AstInfo]$parameterAstInfo) {
         $this.Initialize(

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
@@ -32,6 +32,10 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
     # A description of the parameter's purpose and usage.
     [string] $Description = ''
 
+    static OverloadParameterHelpInfo() {
+        [OverloadParameterHelpInfo]::InitializeFormatters()
+    }
+
     OverloadParameterHelpInfo() {}
 
     OverloadParameterHelpInfo([OrderedDictionary]$metadata) : base($metadata) {}
@@ -199,5 +203,229 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
         $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
 
         return $metadata
+    }
+
+    static [HelpInfoFormatterDictionary] $Formatters
+
+    static InitializeFormatters() {
+        [OverloadParameterHelpInfo]::InitializeFormatters($false, $false)
+    }
+
+    static [HelpInfoFormatterDictionary] InitializeFormatters([bool]$passThru, [bool]$force) {
+        if ($force -or [OverloadParameterHelpInfo]::Formatters.Count -eq 0) {
+            [OverloadParameterHelpInfo]::Formatters = [HelpInfoFormatterDictionary]::new(
+                [ordered]@{
+                    Block    = [OverloadParameterHelpInfo]::GetDefaultFormatter()
+                    ListItem = [OverloadParameterHelpInfo]::GetListItemFormatter()
+                },
+                [ordered]@{
+                    Block = [OverloadParameterHelpInfo]::GetDefaultSectionFormatter()
+                    List  = [OverloadParameterHelpInfo]::GetListSectionFormatter()
+                }
+            )
+        }
+
+        if ($passThru) {
+            return [OverloadParameterHelpInfo]::Formatters
+        }
+
+        return $null
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadParameterHelpInfo]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 4
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $Title = '{0} ({1})' -f $HelpInfo.Name, $HelpInfo.Type
+
+                $MarkdownBuilder | Add-Heading -Level $Level -Content $Title
+
+                $Description = $HelpInfo.Description
+                if ([string]::IsNullOrEmpty($Description)) {
+                    $Description = '<!-- TODO: Add a description. -->'
+                }
+
+                if (-not [string]::IsNullOrEmpty($HelpInfo.Description)) {
+                    $lines = $Description -split '\r?\n'
+                    foreach ($line in $lines) {
+                        $MarkdownBuilder | Add-Line -Content $line
+                    }
+                }
+
+                return $MarkdownBuilder.ToString()
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetListItemFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadParameterHelpInfo]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 4
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $Title = '`${0}` (**{1}**)' -f $HelpInfo.Name, $HelpInfo.Type
+
+                $Description = $HelpInfo.Description
+                if ([string]::IsNullOrEmpty($Description)) {
+                    $Description = '<!-- TODO: Add a description. -->'
+                }
+
+                $MarkdownBuilder |
+                    Add-Line -Content $Title |
+                    Add-Line |
+                    Add-Line -Content $Description
+
+                return $MarkdownBuilder.ToString()
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetDefaultSectionFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadParameterHelpInfo[]]
+                    $HelpInfo,
+
+                    [string]
+                    $Prefix,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [ValidateRange(1, 5)]
+                    [int]
+                    $Level = 3
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder | Add-Heading -Level $Level -Content 'Parameters'
+
+                foreach ($param in $HelpInfo) {
+                    $formatter = [OverloadParameterHelpInfo]::Formatters.Block
+                    $formatter.Parameters.Level = $Level + 1
+
+                    $MarkdownBuilder | Add-Line -Content $param.ToMarkdown($formatter)
+                }
+
+                return ($MarkdownBuilder.ToString() -replace '(\r?\n)+$', '$1')
+            }
+        }
+    }
+
+    hidden static [HelpInfoFormatter] GetListSectionFormatter() {
+        return [HelpInfoFormatter]@{
+            Parameters  = @{}
+            ScriptBlock = {
+                [CmdletBinding()]
+                [OutputType([string])]
+                param(
+                    [Parameter(Mandatory)]
+                    [OverloadParameterHelpInfo[]]
+                    $HelpInfo,
+
+                    [MarkdownBuilder]
+                    $MarkdownBuilder,
+
+                    [string]
+                    $Prefix,
+
+                    [ValidateRange(1, 6)]
+                    [int]
+                    $Level = 5,
+
+                    [string]
+                    $HeadingText = 'Parameters'
+                )
+
+                if ($null -eq $MarkdownBuilder) {
+                    $options = @{
+                        SpaceMungingOptions = 'CollapseEnd', 'TrimStart'
+                    }
+                    $MarkdownBuilder = Documentarian.MarkdownBuilder\New-Builder @options
+                }
+
+                $MarkdownBuilder |
+                    Add-Heading -Level $Level -Content $HeadingText |
+                    Start-List
+
+                foreach ($param in $HelpInfo) {
+                    $formatter = [OverloadParameterHelpInfo]::Formatters.ListItem
+                    $formatted = $param.ToMarkdown($formatter)
+
+                    $MarkdownBuilder | Add-ListItem -ListItem $formatted
+                }
+
+                $MarkdownBuilder.EndList().ToString()
+            }
+        }
+    }
+
+    [string] ToMarkdown() {
+        return $this.ToMarkdown([OverloadParameterHelpInfo]::Formatters.Default)
+    }
+
+    [string] ToMarkdown([HelpInfoFormatter]$formatter) {
+        return $formatter.Format($this)
+    }
+
+    static [string] ToMarkdown([OverloadParameterHelpInfo[]]$values) {
+        return [OverloadParameterHelpInfo]::ToMarkdown($values, [OverloadParameterHelpInfo]::Formatters.Section.Default)
+    }
+
+    static [string] ToMarkdown([OverloadParameterHelpInfo[]]$values, [HelpInfoFormatter]$formatter) {
+        return $formatter.FormatSection($values)
     }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
@@ -4,6 +4,7 @@
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Specialized
 using module ../AstInfo.psm1
+using module ../DecoratingComments/DecoratingCommentsBlockParsed.psm1
 using module ../DecoratingComments/DecoratingCommentsRegistry.psm1
 using module ./BaseHelpInfo.psm1
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadParameterHelpInfo.psm1
@@ -172,4 +172,12 @@ class OverloadParameterHelpInfo : BaseHelpInfo {
         }
         return (Find-Ast @FindValueParameters)
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Name = $metadata.Name | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Type = $metadata.Type | yayaml\Add-YamlFormat -ScalarStyle Plain -PassThru
+        $metadata.Description = $metadata.Description | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
@@ -33,6 +33,12 @@ class OverloadSignature : BaseHelpInfo {
     #>
     [string] $TypeOnly
 
+    <#
+        A list of the parameter types for the overload. This is the same as the
+        **TypeOnly** property, but as a list instead of a string.
+    #>
+    [string[]] $ParameterTypes = @()
+
     [string] ToString() {
         <#
             .SYNOPSIS
@@ -46,7 +52,53 @@ class OverloadSignature : BaseHelpInfo {
             This method is automatically called when an **OverloadSignature**
             is interpolated into a string.
         #>
+
         return $this.Full
+    }
+
+    [string] ToCodeBlock() {
+        <#
+            .SYNOPSIS
+            Returns a string representing the full signature as a code block.
+
+            .DESCRIPTION
+            Returns a string representing the full signature as a code block. If the length of the
+            signature is 76 characters or longer, the method formats the signature as a multiline
+            code block, with each parameter on its own line. If the length of the signature is less
+            than 76 characters, the method formats the signature as a single-line code block.
+        #>
+
+        $multiline = $this.Full.Length -ge 76
+
+        return $this.ToCodeBlock($multiline)
+    }
+
+    [string] ToCodeBlock([bool]$multiline) {
+        <#
+            .SYNOPSIS
+            Returns a string representing the full signature as a code block.
+
+            .DESCRIPTION
+            Returns a string representing the full signature as a code block. The value of the
+            `$multiline` parameter determines whether the signature is formatted as a single-line
+            code block or a multiline code block. For a multiline code block, each parameter is
+            placed on its own line.
+
+            .PARAMETER multiline
+            Determines whether the signature is formatted as a single-line code block or a multiline
+            code block.
+        #>
+        $output = $this.Full
+
+        if ($Multiline) {
+            $output = $output -replace '\(', "(`n$(([string]::Empty).PadRight(4))"
+            $output = $output -replace ', ', ",`n$(([string]::Empty).PadRight(4))"
+            $output = $output -replace '\)', "`n)"
+        }
+
+        $output = '```powershell' + "`n" + $output + "`n" + '```'
+
+        return $output
     }
 
     OverloadSignature() {}
@@ -62,26 +114,30 @@ class OverloadSignature : BaseHelpInfo {
     }
 
     hidden [void] Initialize([FunctionMemberAst]$overloadAst) {
-        $this.Full     = [OverloadSignature]::GetFullSignature($overloadAst)
-        $this.TypeOnly = [OverloadSignature]::GetTypeOnlySignature($overloadAst)
+        $this.Full           = [OverloadSignature]::GetFullSignature($overloadAst)
+        $this.TypeOnly       = [OverloadSignature]::GetTypeOnlySignature($overloadAst)
+        $this.ParameterTypes = [OverloadSignature]::GetParameterTypes($overloadAst)
     }
 
-    static [string] GetTypeOnlySignature([FunctionMemberAst]$overloadAst) {
-        $Name           = $overloadAst.Name
-        $ParameterTypes = $overloadAst.Parameters | ForEach-Object -Process {
-            $Type = $_.StaticType.FullName
+    static [string[]] GetParameterTypes([FunctionMemberAst]$overloadAst) {
+        return $overloadAst.Parameters | ForEach-Object -Process {
+            $type = $_.StaticType.FullName
 
             # For custom types the parser doesn't know about, they're listed as an
             # attribute instead. We should use that as the type name if available.
-            if ($Type -eq 'System.Object' -and $_.Attributes.Count -gt 0) {
-                $Type = Resolve-TypeName -TypeName $_.Attributes[0].TypeName
+            if ($type -eq 'System.Object' -and $_.Attributes.Count -gt 0) {
+                $type = Resolve-TypeName -TypeName $_.Attributes[0].TypeName
             }
 
-            $Type
+            $type
         }
-        $Parameters = $ParameterTypes -join ', '
+    }
 
-        return "$Name($Parameters)"
+    static [string] GetTypeOnlySignature([FunctionMemberAst]$overloadAst) {
+        $name       = $overloadAst.Name
+        $parameters = [OverloadSignature]::GetParameterTypes($overloadAst) -join ', '
+
+        return "$name($parameters)"
     }
 
     static [string] GetTypeOnlySignature([AstInfo]$overloadAstInfo) {
@@ -89,10 +145,10 @@ class OverloadSignature : BaseHelpInfo {
     }
 
     static [string] GetFullSignature([FunctionMemberAst]$overloadAst) {
-        $Name       = $overloadAst.Name
-        $Parameters = $overloadAst.Parameters.Extent.Text -join ', '
+        $name       = $overloadAst.Name
+        $parameters = $overloadAst.Parameters.Extent.Text -join ', '
 
-        return "$Name($Parameters)"
+        return "$name($parameters)"
     }
 
     static [string] GetFullSignature([AstInfo]$overloadAstInfo) {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
@@ -50,6 +50,8 @@ class OverloadSignature : BaseHelpInfo {
     }
 
     OverloadSignature() {}
+    OverloadSignature([OrderedDictionary]$metadata) : base($metadata) {
+    }
     
     OverloadSignature([FunctionMemberAst]$overloadAst) {
         $this.Initialize($overloadAst)

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
@@ -95,4 +95,11 @@ class OverloadSignature : BaseHelpInfo {
     static [string] GetFullSignature([AstInfo]$overloadAstInfo) {
         return [OverloadSignature]::GetFullSignature($overloadAstInfo)
     }
+
+    hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
+        $metadata.Full = $metadata.Full | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+        $metadata.TypeOnly = $metadata.TypeOnly | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+
+        return $metadata
+    }
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/HelpInfo/OverloadSignature.psm1
@@ -10,13 +10,13 @@ using module ./BaseHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Resolve-TypeName.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -50,24 +50,24 @@ class OverloadSignature : BaseHelpInfo {
     }
 
     OverloadSignature() {}
-    OverloadSignature([OrderedDictionary]$metadata) : base($metadata) {
-    }
-    
+
+    OverloadSignature([OrderedDictionary]$metadata) : base($metadata) {}
+
     OverloadSignature([FunctionMemberAst]$overloadAst) {
         $this.Initialize($overloadAst)
     }
-    
+
     OverloadSignature([AstInfo]$overloadAstInfo) {
         $this.Initialize($overloadAstInfo.Ast)
     }
 
     hidden [void] Initialize([FunctionMemberAst]$overloadAst) {
-        $this.Full = [OverloadSignature]::GetFullSignature($overloadAst)
+        $this.Full     = [OverloadSignature]::GetFullSignature($overloadAst)
         $this.TypeOnly = [OverloadSignature]::GetTypeOnlySignature($overloadAst)
     }
 
     static [string] GetTypeOnlySignature([FunctionMemberAst]$overloadAst) {
-        $Name = $overloadAst.Name
+        $Name           = $overloadAst.Name
         $ParameterTypes = $overloadAst.Parameters | ForEach-Object -Process {
             $Type = $_.StaticType.FullName
 
@@ -83,24 +83,25 @@ class OverloadSignature : BaseHelpInfo {
 
         return "$Name($Parameters)"
     }
-    
+
     static [string] GetTypeOnlySignature([AstInfo]$overloadAstInfo) {
         return [OverloadSignature]::GetTypeOnlySignature($overloadAstInfo.Ast)
     }
-    
+
     static [string] GetFullSignature([FunctionMemberAst]$overloadAst) {
-        $Name = $overloadAst.Name
+        $Name       = $overloadAst.Name
         $Parameters = $overloadAst.Parameters.Extent.Text -join ', '
+
         return "$Name($Parameters)"
     }
-    
+
     static [string] GetFullSignature([AstInfo]$overloadAstInfo) {
         return [OverloadSignature]::GetFullSignature($overloadAstInfo)
     }
 
     hidden static [OrderedDictionary] AddYamlFormatting([OrderedDictionary]$metadata) {
-        $metadata.Full = $metadata.Full | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
-        $metadata.TypeOnly = $metadata.TypeOnly | yayaml\Add-YamlFormat -ScalarStyle Folded -PassThru
+        $metadata.Full     = $metadata.Full     | yayaml\Add-YamlFormat -ScalarStyle Literal -PassThru
+        $metadata.TypeOnly = $metadata.TypeOnly | yayaml\Add-YamlFormat -ScalarStyle Folded  -PassThru
 
         return $metadata
     }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/ParameterInfo.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Classes/ParameterInfo.psm1
@@ -42,30 +42,32 @@ class ParameterInfo {
     [System.Management.Automation.ParameterMetadata]$param,
     [ProviderFlags]$ProviderFlags
   ) {
-    $this.Name = $param.Name
+    $this.Name     = $param.Name
     $this.HelpText = $param.Attributes.HelpMessage | Select-Object -First 1
     if ($this.HelpText.Length -eq 0) {
       $this.HelpText = '{{Placeholder}}'
     }
-    $this.Type = $param.ParameterType.FullName
+    $this.Type         = $param.ParameterType.FullName
     $this.ParameterSet = if ($param.Attributes.ParameterSetName -eq '__AllParameterSets') {
       '(All)'
     } else {
       $param.Attributes.ParameterSetName -join ', '
     }
-    $this.Aliases = $param.Aliases -join ', '
+    $this.Aliases  = $param.Aliases -join ', '
     $this.Required = $param.Attributes.Mandatory
     $this.Position = if ($param.Attributes.Position -lt 0) {
       'Named'
     } else {
       $param.Attributes.Position
     }
-    $this.Pipeline = 'ByValue ({0}), ByName ({1})' -f ($param.Attributes.ValueFromPipeline -join ','),
-      ($param.Attributes.ValueFromPipelineByPropertyName -join ',')
-    $this.Wildcard = $param.Attributes.TypeId.Name -contains 'SupportsWildcardsAttribute'
-    $this.Dynamic = $param.IsDynamic
+    $this.Pipeline = 'ByValue ({0}), ByName ({1})' -f @(
+            ($param.Attributes.ValueFromPipeline -join ','),
+            ($param.Attributes.ValueFromPipelineByPropertyName -join ',')
+    )
+    $this.Wildcard      = $param.Attributes.TypeId.Name -contains 'SupportsWildcardsAttribute'
+    $this.Dynamic       = $param.IsDynamic
     $this.FromRemaining = $param.Attributes.ValueFromRemainingArguments
-    $this.DontShow = $param.Attributes.DontShow
+    $this.DontShow      = $param.Attributes.DontShow
     if ($param.Attributes.TypeId.Name -contains 'PSDefaultValueAttribute') {
       $this.DefaultValue = $param.Attributes.Help -join ', '
     } else {
@@ -89,20 +91,20 @@ class ParameterInfo {
 
   [string]ToMarkdown([bool]$showAll) {
     <#
-      .SYNOPSIS
-        Converts the parameter info to a Markdown section.
-      .DESCRIPTION
-        Converts the parameter info to a Markdown section as expected by the
-        **PlatyPS** module. It includes an H3 for the parameter (with the
-        leading hyphen), the parameter's help text, and a YAML code block
-        containing the parameter's metadata.
+            .SYNOPSIS
+                Converts the parameter info to a Markdown section.
+            .DESCRIPTION
+                Converts the parameter info to a Markdown section as expected by the
+                **PlatyPS** module. It includes an H3 for the parameter (with the
+                leading hyphen), the parameter's help text, and a YAML code block
+                containing the parameter's metadata.
 
-        When the $showAll parameter is $true, the parameter's non-PlatyPS
-        compliant metadata is included.
+                When the $showAll parameter is $true, the parameter's non-PlatyPS
+                compliant metadata is included.
 
-      .PARAMETER showAll
-        Whether to include the parameter's non-PlatyPS compliant metadata.
-    #>
+            .PARAMETER showAll
+                Whether to include the parameter's non-PlatyPS compliant metadata.
+        #>
 
     $builder = New-Builder
     $Builder | Add-Heading -Level 3 -Content $this.Name
@@ -111,9 +113,10 @@ class ParameterInfo {
     $Builder | Add-Line -Content "Type: $($this.Type)"
     $Builder | Add-Line -Content "Parameter Sets: $($this.ParameterSet)"
     $Builder | Add-Line -Content "Aliases: $($this.Aliases)"
+    $Builder | Add-Line
     $Builder | Add-Line -Content "Required: $($this.Required -join ', ')"
     $Builder | Add-Line -Content "Position: $($this.Position -join ', ')"
-    if ($this.Type -eq 'System.Management.Automation.SwitchParameter') {
+    if ($this.Type -is [System.Management.Automation.SwitchParameter]) {
       $Builder | Add-Line -Content 'Default value: False'
     } else {
       $Builder | Add-Line -Content "Default value: $($this.DefaultValue)"

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Enums/DecoratingCommentsBlockKeywordKind.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Enums/DecoratingCommentsBlockKeywordKind.psm1
@@ -36,7 +36,7 @@ enum DecoratingCommentsBlockKeywordKind {
         ```powershell
         [DecoratingCommentsBlockKeywordKind]::BlockAndValue
         ```
-        
+
         Gets the `BlockAndValue` enumeration.
     #>
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Enums/ProviderFlags.psm1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Enums/ProviderFlags.psm1
@@ -1,13 +1,13 @@
-﻿# Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 [Flags()] enum ProviderFlags {
-  Registry = 0x01
-  Alias = 0x02
-  Environment = 0x04
-  FileSystem = 0x08
-  Function = 0x10
-  Variable = 0x20
-  Certificate = 0x40
-  WSMan = 0x80
+    Registry    = 0x01
+    Alias       = 0x02
+    Environment = 0x04
+    FileSystem  = 0x08
+    Function    = 0x10
+    Variable    = 0x20
+    Certificate = 0x40
+    WSMan       = 0x80
 }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/AstInfo/Find-Ast.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/AstInfo/Find-Ast.ps1
@@ -10,15 +10,15 @@ using module ../../Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/New-AstPredicate.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/New-AstPredicate.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -31,25 +31,25 @@ Function Find-Ast {
 
     [CmdletBinding(DefaultParameterSetName = 'FromAstInfoWithType')]
     [OutputType([Ast[]], ParameterSetName=(
-        'FromAstInfoWithPredicate',
-        'FromPathWithPredicate',
-        'FromScriptBlockWithPredicate',
-        'FromTargetAstWithPredicate',
-        'FromAstInfoWithType',
-        'FromPathWithType',
-        'FromScriptBlockWithType',
-        'FromTargetAstWithType'
-    ))]
+            'FromAstInfoWithPredicate',
+            'FromPathWithPredicate',
+            'FromScriptBlockWithPredicate',
+            'FromTargetAstWithPredicate',
+            'FromAstInfoWithType',
+            'FromPathWithType',
+            'FromScriptBlockWithType',
+            'FromTargetAstWithType'
+        ))]
     [OutputType([AstInfo[]], ParameterSetName=(
-        'FromAstInfoWithPredicateAsAstInfo',
-        'FromPathWithPredicateAsAstInfo',
-        'FromScriptBlockWithPredicateAsAstInfo',
-        'FromTargetAstWithPredicateAsAstInfo',
-        'FromAstInfoWithTypeAsAstInfo',
-        'FromPathWithTypeAsAstInfo',
-        'FromScriptBlockWithTypeAsAstInfo',
-        'FromTargetAstWithTypeAsAstInfo'
-    ))]
+            'FromAstInfoWithPredicateAsAstInfo',
+            'FromPathWithPredicateAsAstInfo',
+            'FromScriptBlockWithPredicateAsAstInfo',
+            'FromTargetAstWithPredicateAsAstInfo',
+            'FromAstInfoWithTypeAsAstInfo',
+            'FromPathWithTypeAsAstInfo',
+            'FromScriptBlockWithTypeAsAstInfo',
+            'FromTargetAstWithTypeAsAstInfo'
+        ))]
     Param(
         [Parameter(Mandatory, ParameterSetName = 'FromAstInfoWithPredicate')]
         [Parameter(Mandatory, ParameterSetName = 'FromAstInfoWithPredicateAsAstInfo')]
@@ -183,8 +183,8 @@ Function Find-Ast {
             $Results | ForEach-Object -Process {
                 $GetResultParameters = @{
                     ParseDecoratingComment = $ParseDecoratingComment
-                    TargetAst = $_
-                    Token = $AstInfo.Tokens
+                    TargetAst              = $_
+                    Token                  = $AstInfo.Tokens
                 }
                 if ($null -ne $Registry) {
                     $GetResultParameters.Registry = $Registry

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/AstInfo/Get-AstInfo.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/AstInfo/Get-AstInfo.ps1
@@ -8,13 +8,13 @@ using module ../../Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -30,18 +30,31 @@ Function Get-AstInfo {
     param(
         [Parameter(Mandatory, ParameterSetName = 'FromPath')]
         [ValidatePowerShellScriptPath()]
-        [string[]]$Path,
+        [string[]]
+        $Path,
+
         [Parameter(Mandatory, ParameterSetName = 'FromScriptBlock')]
-        [scriptblock[]]$ScriptBlock,
+        [scriptblock[]]
+        $ScriptBlock,
+
         [Parameter(Mandatory, ParameterSetName = 'FromInputText')]
         [ValidateNotNullOrEmpty()]
-        [string[]]$Text,
+        [string[]]
+        $Text,
+
         [Parameter(Mandatory, ParameterSetName = 'FromTargetAst')]
-        [Ast[]]$TargetAst,
+        [Ast[]]
+        $TargetAst,
+
         [Parameter(ParameterSetName = 'FromTargetAst')]
-        [Token[]]$Token,
-        [DecoratingCommentsRegistry]$Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
-        [switch]$ParseDecoratingComment
+        [Token[]]
+        $Token,
+
+        [DecoratingCommentsRegistry]
+        $Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
+
+        [switch]
+        $ParseDecoratingComment
     )
 
     begin {}

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/AstInfo/Get-AstType.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/AstInfo/Get-AstType.ps1
@@ -5,13 +5,13 @@
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Test-IsAstType.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Test-IsAstType.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -28,25 +28,27 @@ Function Get-AstType {
         [Parameter(
             Mandatory,
             ParameterSetName = 'ByPattern',
-            HelpMessage = 'Specify a valid regex pattern to match in the list of AST types'
+            HelpMessage      = 'Specify a valid regex pattern to match in the list of AST types'
         )]
-        [string]$Pattern,
+        [string]
+        $Pattern,
 
         [Parameter(
             Mandatory,
             ParameterSetName = 'ByName',
-            HelpMessage = 'Specify a name to look for in the list of AST types; the "Ast" suffix is optional'
+            HelpMessage      = 'Specify a name to look for in the list of AST types; the "Ast" suffix is optional'
         )]
-        [string[]]$Name
+        [string[]]
+        $Name
     )
 
     begin {
         # ignore exceptions getting the types in an assembly
         $Types = [System.AppDomain]::CurrentDomain.GetAssemblies() |
-        ForEach-Object -Process { try { $_.GetTypes() } catch {} } |
-        Where-Object -FilterScript {
-            Test-IsAstType -Type $_
-        }
+            ForEach-Object -Process { try { $_.GetTypes() } catch {} } |
+            Where-Object -FilterScript {
+                Test-IsAstType -Type $_
+            }
     }
 
     process {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Get-DcBlockSchema.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Get-DcBlockSchema.ps1
@@ -110,4 +110,3 @@ function Get-DcBlockSchema {
         $Schemas
     }
 }
-

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Get-DcBlockSchema.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Get-DcBlockSchema.ps1
@@ -12,19 +12,23 @@ function Get-DcBlockSchema {
         [Parameter(ParameterSetName='ByValueFromAny')]
         [Parameter(ParameterSetName='ByValueFromBuiltIn')]
         [Parameter(ParameterSetName='ByValueFromRegistry')]
-        [string[]]$SchemaValue,
+        [string[]]
+        $SchemaValue,
 
         [Parameter(ParameterSetName='ByNameFromAny')]
         [Parameter(ParameterSetName='ByNameFromBuiltIn')]
         [Parameter(ParameterSetName='ByNameFromRegistry')]
-        [string[]]$Name,
+        [string[]]
+        $Name,
 
         [Parameter(ParameterSetName='ByAliasFromAny')]
         [Parameter(ParameterSetName='ByAliasFromBuiltIn')]
         [Parameter(ParameterSetName='ByAliasFromRegistry')]
-        [string[]]$Alias,
+        [string[]]
+        $Alias,
 
-        [DecoratingCommentsBlockKeyword[]]$IncludesKeyword,
+        [DecoratingCommentsBlockKeyword[]]
+        $IncludesKeyword,
 
         [Parameter(ParameterSetName='ByValueFromAny')]
         [Parameter(ParameterSetName='ByValueFromRegistry')]
@@ -32,17 +36,20 @@ function Get-DcBlockSchema {
         [Parameter(ParameterSetName='ByNameFromRegistry')]
         [Parameter(ParameterSetName='ByAliasFromAny')]
         [Parameter(ParameterSetName='ByAliasFromRegistry')]
-        [DecoratingCommentsRegistry]$Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
+        [DecoratingCommentsRegistry]
+        $Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
 
         [Parameter(ParameterSetName='ByValueFromBuiltIn')]
         [Parameter(ParameterSetName='ByNameFromBuiltIn')]
         [Parameter(ParameterSetName='ByAliasFromBuiltIn')]
-        [switch]$BuiltInOnly,
+        [switch]
+        $BuiltInOnly,
 
         [Parameter(ParameterSetName='ByValueFromRegistry')]
         [Parameter(ParameterSetName='ByNameFromRegistry')]
         [Parameter(ParameterSetName='ByAliasFromRegistry')]
-        [switch]$RegisteredOnly
+        [switch]
+        $RegisteredOnly
     )
 
     process {
@@ -59,6 +66,7 @@ function Get-DcBlockSchema {
                 'of the command to a variable, then pass it to this command as a parameter.'
             ) -join ' '
             Write-Error $Message
+
             return
         } elseif ($null -ne $Registry) {
             $Schemas = $Registry.GetEnumeratedRegisteredSchemas()
@@ -67,34 +75,39 @@ function Get-DcBlockSchema {
         }
 
         if ($SchemaValue.Count -gt 0) {
-            Write-Verbose "Filtering for Schema Value"
+            Write-Verbose 'Filtering for Schema Value'
+
             $Schemas = $Schemas | Where-Object -FilterScript {
-                ($_.GetName() -in $SchemaValue) -or 
-                ($_.GetAliases().Where({$_ -in $SchemaValue}).Count -gt 0)
+                ($_.GetName() -in $SchemaValue) -or
+                ($_.GetAliases().Where{ $_ -in $SchemaValue }.Count -gt 0)
             }
         }
 
         if ($Name.Count -gt 0) {
-            Write-Verbose "Filtering for Name"
+            Write-Verbose 'Filtering for Name'
+
             $Schemas = $Schemas | Where-Object -FilterScript {
                 $_.GetName() -in $Name
             }
         }
 
         if ($Alias.Count -gt 0) {
-            Write-Verbose "Filtering for Alias"
+            Write-Verbose 'Filtering for Alias'
+
             $Schemas = $Schemas | Where-Object -FilterScript {
-                $_.GetAliases().Where({$_ -in $Alias}).Count -gt 0
+                $_.GetAliases().Where{ $_ -in $Alias }.Count -gt 0
             }
         }
 
         if ($IncludesKeyword.Count -gt 0) {
-            Write-Verbose "Filtering for Keywords"
+            Write-Verbose 'Filtering for Keywords'
+
             $Schemas = $Schemas | Where-Object -FilterScript {
-                $_.GetKeywords().Where({ $_ -in $IncludesKeyword }).Count -gt 0
+                $_.GetKeywords().Where{ $_ -in $IncludesKeyword }.Count -gt 0
             }
         }
 
         $Schemas
     }
 }
+

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Initialize-DcGlobalRegistry.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Initialize-DcGlobalRegistry.ps1
@@ -9,13 +9,13 @@ using module ../../Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -24,15 +24,24 @@ function Initialize-DcGlobalRegistry {
     [cmdletbinding()]
     [OutputType([DecoratingCommentsRegistry])]
     param(
-        [DecoratingCommentsBlockSchema[]]$Schema,
-        [DecoratingCommentsBlockKeyword[]]$Keyword,
-        [switch]$WithoutDefaults,
-        [switch]$Force,
-        [switch]$PassThru
+        [DecoratingCommentsBlockSchema[]]
+        $Schema,
+
+        [DecoratingCommentsBlockKeyword[]]
+        $Keyword,
+
+        [switch]
+        $WithoutDefaults,
+
+        [switch]
+        $Force,
+
+        [switch]
+        $PassThru
     )
 
     begin {
-        $GlobalRegistryExists = $null -ne $Global:ModuleAuthorDecoratingCommentsRegistry
+        $GlobalRegistryExists       = $null -ne $Global:ModuleAuthorDecoratingCommentsRegistry
         $ValidNewRegistryParameters = Get-Command -Name New-DecoratingCommentsRegistry |
             ForEach-Object -Process { $_.Parameters.Keys }
     }
@@ -41,14 +50,10 @@ function Initialize-DcGlobalRegistry {
         $NewRegistryParameters = @{}
 
         if ($GlobalRegistryExists) {
-            Write-Verbose "Reinitializing the global registry"
+            Write-Verbose 'Reinitializing the global registry'
 
-            if ($null -eq $Schema) {
-                $Schema = @()
-            }
-            if ($null -eq $Keyword) {
-                $Keyword = @()
-            }
+            if ($null -eq $Schema) { $Schema  = @() }
+            if ($null -eq $Keyword) { $Keyword = @() }
 
             if ($WithoutDefaults) {
                 $Global:ModuleAuthorDecoratingCommentsRegistry.InitializeWithoutDefaults(
@@ -64,7 +69,8 @@ function Initialize-DcGlobalRegistry {
                 )
             }
         } else {
-            Write-Verbose "Creating the global registry"
+            Write-Verbose 'Creating the global registry'
+
             $p = @{}
             foreach ($Parameter in $PSBoundParameters.Keys) {
                 if ($Parameter -in $ValidNewRegistryParameters) {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/New-DcBlockKeyword.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/New-DcBlockKeyword.ps1
@@ -9,29 +9,33 @@ function New-DcBlockKeyword {
     [OutputType([DecoratingCommentsBlockKeyword[]])]
     param(
         [Parameter(Mandatory)]
-        [string[]]$Name,
-        [DecoratingCommentsBlockKeywordKind]$Kind,
-        [switch]$SupportMultipleEntries,
-        [regex]$Pattern
+        [string[]]
+        $Name,
+
+        [DecoratingCommentsBlockKeywordKind]
+        $Kind,
+
+        [switch]
+        $SupportMultipleEntries,
+
+        [regex]
+        $Pattern
     )
 
     process {
         $Signature = 'Name'
-        if ($null -ne $Kind) {
-            $Signature += 'Kind'
-        }
-        if ($null -ne $Pattern) {
-            $Signature += 'Pattern'
-        }
+        if ($null -ne $Kind) { $Signature += 'Kind' }
+        if ($null -ne $Pattern) { $Signature += 'Pattern' }
+
         foreach ($KeywordName in $Name) {
             switch ($Signature) {
                 'Name' {
-                    [DecoratingCommentsBlockKeyword]::new($Name, $SupportMultipleEntries) 
+                    [DecoratingCommentsBlockKeyword]::new($Name, $SupportMultipleEntries)
                 }
                 'NameKind' {
                     [DecoratingCommentsBlockKeyword]::new($Name, $Kind, $SupportMultipleEntries)
                 }
-                'NamePattern'{
+                'NamePattern' {
                     [DecoratingCommentsBlockKeyword]::new(
                         $Name,
                         $SupportMultipleEntries,

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/New-DcBlockSchemaDefinition.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/New-DcBlockSchemaDefinition.ps1
@@ -8,13 +8,13 @@ using module ../../Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/Get-DcBlockKeyword.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/Get-DcBlockKeyword.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -24,13 +24,22 @@ function New-DcBlockSchemaDefinition {
     [OutputType([string])]
     param(
         [Parameter(Mandatory)]
-        [string]$Name,
-        [string[]]$Alias,
+        [string]
+        $Name,
+
+        [string[]]
+        $Alias,
+
         [Parameter(Mandatory, ParameterSetName = 'WithKeywordNames')]
-        [string[]]$KeywordName,
+        [string[]]
+        $KeywordName,
+
         [Parameter(ParameterSetName = 'WithKeywordObjects')]
-        [DecoratingCommentsBlockKeyword[]]$Keyword,
-        [DecoratingCommentsRegistry]$Registry = $Global:ModuleAuthorDecoratingCommentsRegistry
+        [DecoratingCommentsBlockKeyword[]]
+        $Keyword,
+
+        [DecoratingCommentsRegistry]
+        $Registry = $Global:ModuleAuthorDecoratingCommentsRegistry
     )
 
     begin {}
@@ -39,7 +48,7 @@ function New-DcBlockSchemaDefinition {
         if ($Name -notmatch '\w+') {
             $Message = @(
                 "Invalid name '$Name'. The name of a DecoratingCommentsBlockSchema must be a"
-                "string that only contains alphanumeric characters and underscores."
+                'string that only contains alphanumeric characters and underscores.'
             ) -join ' '
             throw $Message
         }
@@ -47,7 +56,7 @@ function New-DcBlockSchemaDefinition {
             if ($A -notmatch '\w+') {
                 $Message = @(
                     "Invalid alias '$A'. Aliases of a DecoratingCommentsBlockSchema must be a"
-                    "string that only contains alphanumeric characters and underscores."
+                    'string that only contains alphanumeric characters and underscores.'
                 ) -join ' '
                 throw $Message
             }
@@ -80,10 +89,16 @@ function New-DcBlockSchemaDefinition {
         }
 
         $ModuleStringBuilder = New-Object -TypeName System.Text.StringBuilder
-        $null = $ModuleStringBuilder.AppendLine('using module Documentarian.ModuleAuthor')
-        $null = $ModuleStringBuilder.AppendLine()
-        $null = $ModuleStringBuilder.AppendLine("class $Name : DecoratingCommentsBlockSchema {")
-        $null = $ModuleStringBuilder.AppendLine("  static [string] `$Name = '$Name'")
+
+        $null = $ModuleStringBuilder.AppendLine(
+            'using module Documentarian.ModuleAuthor'
+        ).AppendLine(
+            ''
+        ).AppendLine(
+            "class $Name : DecoratingCommentsBlockSchema {"
+        ).AppendLine(
+            "  static [string] `$Name = '$Name'"
+        )
 
         if ($Alias.Count -gt 0) {
             $null = $ModuleStringBuilder.AppendLine('  static [string[]] $Aliases = @(')
@@ -99,27 +114,24 @@ function New-DcBlockSchemaDefinition {
         foreach ($K in $Keyword) {
             $null = $ModuleStringBuilder.AppendLine(
                 '    [DecoratingCommentsBlockKeyword]@{'
-            )
-            $null = $ModuleStringBuilder.AppendLine(
+            ).AppendLine(
                 "      Name                    = '$($K.Name)'"
-            )
-            $null = $ModuleStringBuilder.AppendLine(
+            ).AppendLine(
                 "      Kind                    = '$($K.Kind)'"
-            )
-            $null = $ModuleStringBuilder.AppendLine(
+            ).AppendLine(
                 "      SupportsMultipleEntries = $($K.SupportsMultipleEntries)"
-            )
-            $null = $ModuleStringBuilder.AppendLine(
+            ).AppendLine(
                 "      Pattern                 = '$($K.Pattern)'"
-            )
-            $null = $ModuleStringBuilder.AppendLine(
+            ).AppendLine(
                 '    }'
             )
         }
-        $null = $ModuleStringBuilder.AppendLine('  )')
-        $null = $ModuleStringBuilder.AppendLine('}')
-        $null = $ModuleStringBuilder.AppendLine()
-        
+        $null = $ModuleStringBuilder.AppendLine(
+            '  )'
+        ).AppendLine(
+            '}'
+        ).AppendLine()
+
         $ModuleStringBuilder.ToString()
     }
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Register-DcBlockKeyword.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Register-DcBlockKeyword.ps1
@@ -8,13 +8,13 @@ using module ../../Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/Get-DcBlockKeyword.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/Get-DcBlockKeyword.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -24,12 +24,21 @@ function Register-DcBlockKeyword {
     [OutputType([DecoratingCommentsBlockKeyword[]])]
     param(
         [Parameter(Mandatory, ParameterSetName='ByKeywordName')]
-        [string[]]$Name,
+        [string[]]
+        $Name,
+
         [Parameter(Mandatory, ParameterSetName='ByKeywordObject')]
-        [DecoratingCommentsBlockKeyword[]]$Keyword,
-        [DecoratingCommentsRegistry]$Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
-        [switch]$Force,
-        [switch]$PassThru
+        [DecoratingCommentsBlockKeyword[]]
+        $Keyword,
+
+        [DecoratingCommentsRegistry]
+        $Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
+
+        [switch]
+        $Force,
+
+        [switch]
+        $PassThru
     )
 
     process {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Register-DcBlockSchema.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/DecoratingComments/Register-DcBlockSchema.ps1
@@ -8,13 +8,13 @@ using module ../../Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/Get-DcBlockSchema.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/Get-DcBlockSchema.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -24,16 +24,29 @@ function Register-DcBlockSchema {
     [OutputType([DecoratingCommentsBlockSchema[]])]
     param(
         [Parameter(Mandatory, ParameterSetName='BySchemaValue')]
-        [string[]]$SchemaValue,
+        [string[]]
+        $SchemaValue,
+
         [Parameter(Mandatory, ParameterSetName='ByName')]
-        [string[]]$Name,
+        [string[]]
+        $Name,
+
         [Parameter(Mandatory, ParameterSetName='ByAlias')]
-        [string[]]$Alias,
+        [string[]]
+        $Alias,
+
         [Parameter(Mandatory, ParameterSetName='BySchemaObject')]
-        [DecoratingCommentsBlockSchema[]]$Schema,
-        [DecoratingCommentsRegistry]$Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
-        [switch]$Force,
-        [switch]$PassThru
+        [DecoratingCommentsBlockSchema[]]
+        $Schema,
+
+        [DecoratingCommentsRegistry]
+        $Registry = $Global:ModuleAuthorDecoratingCommentsRegistry,
+
+        [switch]
+        $Force,
+
+        [switch]
+        $PassThru
     )
 
     process {
@@ -50,7 +63,7 @@ function Register-DcBlockSchema {
 
         if ($null -eq $Schema) {
             $GetParameters = @{
-                Registry = $Registry
+                Registry    = $Registry
                 BuiltInOnly = $true
             }
             if ($SchemaValue.Count -gt 0) {
@@ -62,7 +75,7 @@ function Register-DcBlockSchema {
             if ($Alias.Count -gt 0) {
                 $GetParameters.Alias = $Alias
             }
-            
+
             $Schema = Get-DcBlockSchema @GetParameters
 
             if ($Schema.Count -eq 0) {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Get-Syntax.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Get-Syntax.ps1
@@ -2,12 +2,14 @@
 # Licensed under the MIT License.
 
 function Get-Syntax {
-
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
-        [string]$CmdletName,
-        [switch]$Markdown
+        [string]
+        $CmdletName,
+
+        [switch]
+        $Markdown
     )
 
     function formatString {
@@ -16,7 +18,7 @@ function Get-Syntax {
             $pstring
         )
 
-        $parts = $pstring -split ' '
+        $parts      = $pstring -split ' '
         $parameters = @()
         for ($x = 0; $x -lt $parts.Count; $x++) {
             $p = $parts[$x]
@@ -36,10 +38,9 @@ function Get-Syntax {
         for ($x = 0; $x -lt $parameters.Count; $x++) {
             if ($line.Length + $parameters[$x].Length + 1 -lt 100) {
                 $line += $parameters[$x] + ' '
-            }
-            else {
+            } else {
                 $temp += $line + "`r`n"
-                $line = ' ' + $parameters[$x] + ' '
+                $line  = ' ' + $parameters[$x] + ' '
             }
         }
         $temp + $line.TrimEnd()
@@ -56,12 +57,13 @@ function Get-Syntax {
         }
 
         $syntax = (Get-Command $name).ParameterSets |
-            Select-Object -Property @{n = 'Cmdlet'; e = { $cmdlet.Name } },
-            @{n = 'ParameterSetName'; e = { $_.name } },
-            IsDefault,
-            @{n = 'Parameters'; e = { $_.ToString() } }
-    }
-    catch [System.Management.Automation.CommandNotFoundException] {
+            Select-Object -Property @(
+                @{Name = 'Cmdlet'           ; Expression = { $cmdlet.Name } },
+                @{Name = 'ParameterSetName' ; Expression = { $_.name } },
+                'IsDefault',
+                @{Name = 'Parameters'       ; Expression = { $_.ToString() } }
+            )
+    } catch [System.Management.Automation.CommandNotFoundException] {
         $_.Exception.Message
     }
 
@@ -83,8 +85,7 @@ function Get-Syntax {
             }
             $mdHere -f $s.ParameterSetName, $default, $string
         }
-    }
-    else {
+    } else {
         $syntax
     }
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/HelpInfo/Resolve-ClassHelpInfo.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/HelpInfo/Resolve-ClassHelpInfo.ps1
@@ -10,15 +10,15 @@ using module ../../Classes/HelpInfo/ClassHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -29,12 +29,15 @@ function Resolve-ClassHelpInfo {
     param (
         [Parameter(Mandatory, ParameterSetName = 'ByPath')]
         [ValidatePowerShellScriptPath()]
-        [string[]]$Path,
+        [string[]]
+        $Path,
 
         [Parameter(Mandatory, ParameterSetName = 'ByAstInfo')]
-        [AstInfo[]]$AstInfo,
+        [AstInfo[]]
+        $AstInfo,
 
-        [DecoratingCommentsRegistry]$Registry = [DecoratingCommentsRegistry]::Get()
+        [DecoratingCommentsRegistry]
+        $Registry = [DecoratingCommentsRegistry]::Get()
     )
 
     begin {
@@ -46,7 +49,6 @@ function Resolve-ClassHelpInfo {
         $FindClassPredicate = {
             [CmdletBinding()]
             [OutputType([bool])]
-
             param(
                 [Ast]$AstObject
             )
@@ -91,6 +93,7 @@ function Resolve-ClassHelpInfo {
 
         foreach ($Definition in $AstInfo) {
             Write-Verbose "Parsing the AST for the $($Definition.Ast.Name) class's help info..."
+
             [ClassHelpInfo]::new($Definition, $Registry)
         }
     }

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/HelpInfo/Resolve-EnumHelpInfo.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/HelpInfo/Resolve-EnumHelpInfo.ps1
@@ -10,15 +10,15 @@ using module ../../Classes/HelpInfo/EnumHelpInfo.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -28,24 +28,27 @@ function Resolve-EnumHelpInfo {
     param(
         [Parameter(Mandatory, ParameterSetName = 'ByPath')]
         [ValidatePowerShellScriptPath()]
-        [string[]]$Path,
+        [string[]]
+        $Path,
 
         [Parameter(Mandatory, ParameterSetName = 'ByAstInfo')]
-        [AstInfo[]]$AstInfo,
+        [AstInfo[]]
+        $AstInfo,
 
-        [DecoratingCommentsRegistry]$Registry = [DecoratingCommentsRegistry]::Get()
+        [DecoratingCommentsRegistry]
+        $Registry = [DecoratingCommentsRegistry]::Get()
     )
 
     begin {
         if ($null -eq $Registry) {
             Write-Verbose 'Using default DecoratingCommentsRegistry to parse the AST for help.'
+
             $Registry = New-DecoratingCommentsRegistry
         }
 
         $FindEnumPredicate = {
             [CmdletBinding()]
             [OutputType([bool])]
-
             param(
                 [Ast]$AstObject
             )

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/HelpInfo/Resolve-HelpInfo.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/HelpInfo/Resolve-HelpInfo.ps1
@@ -9,17 +9,17 @@ using module ../../Classes/DecoratingComments/DecoratingCommentsRegistry.psm1
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/HelpInfo/Resolve-ClassHelpInfo.ps1"
-  Resolve-Path -Path "$SourceFolder/Public/Functions/HelpInfo/Resolve-EnumHelpInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Find-Ast.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/AstInfo/Get-AstInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/DecoratingComments/New-DecoratingCommentsRegistry.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/HelpInfo/Resolve-ClassHelpInfo.ps1"
+    Resolve-Path -Path "$SourceFolder/Public/Functions/HelpInfo/Resolve-EnumHelpInfo.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
@@ -29,24 +29,27 @@ function Resolve-HelpInfo {
     param(
         [Parameter(Mandatory, ParameterSetName = 'ByPath')]
         [ValidatePowerShellScriptPath()]
-        [string[]]$Path,
+        [string[]]
+        $Path,
 
         [Parameter(Mandatory, ParameterSetName = 'ByAstInfo')]
-        [AstInfo[]]$AstInfo,
+        [AstInfo[]]
+        $AstInfo,
 
-        [DecoratingCommentsRegistry]$Registry = [DecoratingCommentsRegistry]::Get()
+        [DecoratingCommentsRegistry]
+        $Registry = [DecoratingCommentsRegistry]::Get()
     )
 
     begin {
         if ($null -eq $Registry) {
             Write-Verbose 'Using default DecoratingCommentsRegistry to parse the AST for help.'
+
             $Registry = New-DecoratingCommentsRegistry
         }
 
         $FindDefinitionPredicate = {
             [CmdletBinding()]
             [OutputType([bool])]
-
             param(
                 [Ast]$AstObject
             )
@@ -82,7 +85,7 @@ function Resolve-HelpInfo {
         }
 
         $SharedParameters = @{
-            AstInfo = $AstInfo
+            AstInfo                = $AstInfo
             AsAstInfo              = $true
             Registry               = $Registry
             ParseDecoratingComment = $true

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Update-Headings.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Update-Headings.ps1
@@ -2,16 +2,32 @@
 # Licensed under the MIT License.
 
 function Update-Headings {
-
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [SupportsWildcards()]
-        [string]$Path,
-        [switch]$Recurse
+        [string]
+        $Path,
+
+        [switch]
+        $Recurse
     )
-    $headings = '## Synopsis', '## Syntax', '## Description', '## Examples', '## Parameters',
-                '### CommonParameters', '## Inputs', '## Outputs', '## Notes', '## Related links',
-                '## Short description', '## Long description', '## See also'
+
+    $headings = @(
+        '## Synopsis'
+        '## Syntax'
+        '## Description'
+        '## Examples'
+        '## Parameters'
+        '### CommonParameters'
+        '## Inputs'
+        '## Outputs'
+        '## Notes'
+        '## Related links'
+        '## Short description'
+        '## Long description'
+        '## See also'
+    )
 
     Get-ChildItem $Path -Recurse:$Recurse | ForEach-Object {
         $_.name

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Update-ParameterOrder.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Update-ParameterOrder.ps1
@@ -5,37 +5,37 @@
 
 $SourceFolder = $PSScriptRoot
 while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
-  $SourceFolder = Split-Path -Parent -Path $SourceFolder
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
 }
 $RequiredFunctions = @(
-  Resolve-Path -Path "$SourceFolder/Private/Functions/ParameterInfo/Get-ParameterMdHeaders.ps1"
+    Resolve-Path -Path "$SourceFolder/Private/Functions/ParameterInfo/Get-ParameterMdHeaders.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
-  . $RequiredFunction
+    . $RequiredFunction
 }
 
 #endregion RequiredFunctions
 
 function Update-ParameterOrder {
-
     [CmdletBinding()]
     [OutputType([System.IO.FileInfo])]
     param (
         [Parameter(Mandatory, Position = 0)]
         [SupportsWildcards()]
-        [string[]]$Path
+        [string[]]
+        $Path
     )
 
     $mdfiles = Get-ChildItem $path
 
     foreach ($file in $mdfiles) {
-        $mdtext = Get-Content $file -Encoding utf8
+        $mdtext    = Get-Content $file -Encoding utf8
         $mdheaders = Select-String -Pattern '^#' -Path $file
 
         $unsorted = Get-ParameterMdHeaders $mdheaders
         if ($unsorted.Count -gt 0) {
-            $sorted = $unsorted | Sort-Object Line
-            $newtext = $mdtext[0..($unsorted[0].StartLine - 1)]
+            $sorted        = $unsorted | Sort-Object Line
+            $newtext       = $mdtext[0..($unsorted[0].StartLine - 1)]
             $confirmWhatIf = @()
             foreach ($paramblock in $sorted) {
                 if ( '### -Confirm', '### -WhatIf' -notcontains $paramblock.Line) {

--- a/Projects/Modules/Documentarian.ModuleAuthor/Spec/Fixtures/Full-output.yaml
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Spec/Fixtures/Full-output.yaml
@@ -1,0 +1,236 @@
+Name: HelpInfoTestClassFull
+Synopsis: >-
+  The synopsis for the class.
+Description: |-
+  The description for the class. The class has no Notes, but
+  it does have two examples.
+Examples:
+  - Title: ''
+    Body: |-
+      The first example for the class. It doesn't have a title.
+  - Title: Second Example
+    Body: |-
+      The second example for the class. It has a title.
+Notes: ''
+BaseTypes: []
+Attributes: []
+Constructors:
+  - Signature:
+      Full: |-
+        HelpInfoTestClassFull()
+      TypeOnly: >-
+        HelpInfoTestClassFull()
+    Synopsis: >-
+      Creates an instance of the class with default values for every property.
+    Description: ''
+    Examples: []
+    IsHidden: false
+    Attributes: []
+    Parameters: []
+    Exceptions: []
+Methods:
+  - Name: DoNothing
+    Synopsis: >-
+      Synopsis for this overload.
+    Overloads:
+      - ReturnType: null
+        IsStatic: false
+        Signature:
+          Full: |-
+            DoNothing()
+          TypeOnly: >-
+            DoNothing()
+        Synopsis: >-
+          Synopsis for this overload.
+        Description: |-
+          The external comment is ignored because this overload
+          has a comment block immediately inside the body. The
+          synopsis is used for the method overall because it's the
+          first declared overload and the class comment block doesn't
+          have this method in it.
+        Examples: []
+        IsHidden: false
+        Attributes: []
+        Parameters: []
+        Exceptions: []
+      - ReturnType: null
+        IsStatic: false
+        Signature:
+          Full: |-
+            DoNothing([string]$first)
+          TypeOnly: >-
+            DoNothing(System.String)
+        Synopsis: >-
+          Synopsis for this overload.
+        Description: |-
+          Because this block is immediately before the overload, it's used
+          for the overload's help. This overload has no examples.
+        Examples: []
+        IsHidden: false
+        Attributes: []
+        Parameters:
+          - Name: first
+            Type: System.String
+            Description: |-
+              The documentation for the `$first` parameter.
+        Exceptions: []
+      - ReturnType: null
+        IsStatic: false
+        Signature:
+          Full: |-
+            DoNothing([string]$first, [int]$third)
+          TypeOnly: >-
+            DoNothing(System.String, System.Int32)
+        Synopsis: >-
+          Synopsis for this overload.
+        Description: |-
+          Because this block is immediately inside the overload, it's
+          used for the overload's help. This overload documents the
+          `$first` parameter in the block, but uses a decorating
+          comment for the `$third` parameter.
+        Examples: []
+        IsHidden: false
+        Attributes: []
+        Parameters:
+          - Name: first
+            Type: System.String
+            Description: |-
+              The documentation for the `$first` parameter. This overrides
+              the decorating comment above the parameter.
+          - Name: third
+            Type: System.Int32
+            Description: "Block comment decorating the `$third` parameter. It spans\nmultiple lines.\n\nIt even has a second paragraph.\n        "
+        Exceptions: []
+  - Name: Repeat
+    Synopsis: >-
+      The synopsis for the Repeat method.
+    Overloads:
+      - ReturnType: null
+        IsStatic: false
+        Signature:
+          Full: |-
+            Repeat([string]$a)
+          TypeOnly: >-
+            Repeat(System.String)
+        Synopsis: >-
+          The synopsis for the Repeat method.
+        Description: ''
+        Examples: []
+        IsHidden: false
+        Attributes: []
+        Parameters:
+          - Name: a
+            Type: System.String
+            Description: ''
+        Exceptions: []
+      - ReturnType: null
+        IsStatic: false
+        Signature:
+          Full: |-
+            Repeat([string]$a, [int]$b)
+          TypeOnly: >-
+            Repeat(System.String, System.Int32)
+        Synopsis: >-
+          The synopsis for the Repeat method.
+        Description: |-
+          The description for this overload. Neither parameter is
+          documented. It doesn't have a Synopsis declared or any
+          examples.
+        Examples: []
+        IsHidden: true
+        Attributes: []
+        Parameters:
+          - Name: a
+            Type: System.String
+            Description: ''
+          - Name: b
+            Type: System.Int32
+            Description: ''
+        Exceptions: []
+  - Name: ToUpper
+    Synopsis: >-
+      The synopsis for this overload.
+    Overloads:
+      - ReturnType: null
+        IsStatic: true
+        Signature:
+          Full: |-
+            ToUpper([string]$a)
+          TypeOnly: >-
+            ToUpper(System.String)
+        Synopsis: >-
+          The synopsis for this overload.
+        Description: |-
+          The description for this overload.
+        Examples:
+          - Title: ''
+            Body: |-
+              An example for this overload. It doesn't have a title.
+          - Title: Another Example
+            Body: |-
+              Another example for this overload. It has a title.
+        IsHidden: false
+        Attributes: []
+        Parameters:
+          - Name: a
+            Type: System.String
+            Description: |-
+              The documentation for the `$a` parameter.
+        Exceptions:
+          - Type: System.ArgumentException
+            Description: |-
+              The exception documentation for this overload. It informs
+              consumers when and why the overload might throw an
+              exception.
+Properties:
+  - Name: First
+    Type: System.String
+    Attributes:
+      - Type: System.Management.Automation.ValidateNotNullOrEmptyAttribute
+        Definition: |-
+          [ValidateNotNullOrEmpty()]
+    InitialValue: null
+    IsHidden: false
+    IsStatic: false
+    Synopsis: >-
+      Synopsis for the First property.
+    Description: |-
+      Description for the First property.
+  - Name: Second
+    Type: System.Int32
+    Attributes: []
+    InitialValue: '3'
+    IsHidden: false
+    IsStatic: true
+    Synopsis: >-
+      A one-line block comment for the Second, its Synopsis.
+    Description: |-
+      Because the Second property has a decorating comment, this
+      value is used as the Description - it's easier to write a
+      longer document here.
+  - Name: Third
+    Type: System.Int32
+    Attributes:
+      - Type: System.Management.Automation.ValidateRangeAttribute
+        Definition: |-
+          [ValidateRange(1, 5)]
+    InitialValue: null
+    IsHidden: true
+    IsStatic: false
+    Synopsis: >-
+      The Third property's Synopsis.
+    Description: |-
+      The Third property's Description.
+  - Name: Fourth
+    Type: System.String
+    Attributes: []
+    InitialValue: "'Default value'"
+    IsHidden: true
+    IsStatic: true
+    Synopsis: >-
+      This is used as the Fourth property's Synopsis, since it has
+
+      the Description key in its decorating block comment.
+    Description: |-
+      The Fourth property's Description.
+LinkReferences: {}

--- a/Projects/Modules/Tools/Update-PSModulePath.ps1
+++ b/Projects/Modules/Tools/Update-PSModulePath.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-#requires -Version 7.2
+
 Function Update-PSModulePath {
   <#
   .SYNOPSIS
@@ -20,7 +20,7 @@ Function Update-PSModulePath {
 
   process {
     $ProjectRoot = Split-Path -Parent -Path $PSScriptRoot
-    $PathSeparator = $IsWindows ? ';' : ':'
+    $PathSeparator = [System.IO.Path]::PathSeparator
     $PathSegments = $env:PSModulePath -split [regex]::Escape($PathSeparator)
 
     if ($PathSegments -notcontains $ProjectRoot) {


### PR DESCRIPTION
# PR Summary

This change adds the `ToYaml` and `ToMarkdown` methods to the `*HelpInfo` classes. Along the way, it also fixes up various other issues and extends the **MarkdownBuilder** module as needed to support the new methods.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I've read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [Microsoft Learn style guide for PowerShell][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/microsoft/Documentarian/blob/main/CONTRIBUTING.md
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
