### PR TITLE
Preload providers in Get-ParameterInfo

### DIFF
--- a/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
+++ b/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
@@ -1,7 +1,7 @@
 {
   "ManifestData": {
     "Guid": "1444d8f2-6b9f-463a-aab6-beadeef7403b",
-    "ModuleVersion": "0.0.1",
+    "ModuleVersion": "0.0.2",
     "RootModule": "Documentarian.ModuleAuthor.psm1",
     "ScriptsToProcess": "Init.ps1",
     "VariablesToExport": "*",
@@ -28,7 +28,7 @@
   "ModuleLicenseNotice": "Licensed under the MIT License.",
   "ModuleLineEnding": "\n",
   "ModuleName": "Documentarian.ModuleAuthor",
-  "ModuleVersion": "0.0.1",
+  "ModuleVersion": "0.0.2",
   "OutputFolderPath": "./[[ManifestData.ModuleVersion]]",
   "SourceFolderPath": "./Source",
   "SourceInitScriptPath": "./Source/Init.ps1",

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Get-ParameterInfo.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Get-ParameterInfo.ps1
@@ -25,6 +25,7 @@ function Get-ParameterInfo {
     )
 
     $cmdlet = Get-Command -Name $CmdletName -ErrorAction Stop
+    $null = Get-PSDrive # Load all providers
     $providerList = Get-PSProvider
 
     foreach ($pname in $ParameterName) {


### PR DESCRIPTION
Preload providers in `Get-ParameterInfo`

Before this PR, `Get-ParameterInfo` would get a list of PowerShell providers using `Get-PSProvider`. If this was run in a brand new session, you are not guaranteed to have all providers loaded. If you run `Get-PSDrive` first, it will force all providers to be loaded that have PSDrives defined. This change calls `Get-PSDrive` before calling `Get-PSProvider` to ensure that `Get-ParameterInfo` is aware of all providers.