### PR TITLE
Prevent Convert-MDLinks from changing link patterns found in code blocks

### DIFF
--- a/Projects/Modules/Documentarian/.DevX.jsonc
+++ b/Projects/Modules/Documentarian/.DevX.jsonc
@@ -2,7 +2,7 @@
 {
   "ManifestData": {
     "RootModule": "Documentarian.psm1",
-    "ModuleVersion": "0.0.1",
+    "ModuleVersion": "0.0.2",
     "CompatiblePSEditions": "Core",
     "GUID": "2422ec90-815c-4c1d-8ec1-4c9b082f2909",
     "Author": "PowerShell Docs Team",

--- a/Projects/Modules/Documentarian/CHANGELOG.md
+++ b/Projects/Modules/Documentarian/CHANGELOG.md
@@ -30,12 +30,13 @@ Related Links
 
 ### Changed
 
-- Replaced dependency on the [powershell-yaml] module with [YaYaml] - this resolves the YamlDotNet
+- Replaced dependency on the [PowerShell-yaml] module with [YaYaml] - this resolves the YamlDotNet
   dependency conflict that prevents the module from being used with PlatyPS. Only the dependency is
   changed, not the functionality.
 
 ### Fixed
 
+- [`Convert-MDLinks`] - filter out matching patterns contained in code blocks.
 - Ensure that [`Convert-MDLinks`] correctly handles all matches found by the regex patterns.
 
 ## 0.0.1 - 2023-03-27

--- a/Projects/Modules/Documentarian/Source/Private/Functions/GetMDLinks.ps1
+++ b/Projects/Modules/Documentarian/Source/Private/Functions/GetMDLinks.ps1
@@ -1,11 +1,28 @@
 ﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+#region    RequiredFunctions
+
+$SourceFolder = $PSScriptRoot
+while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
+    $SourceFolder = Split-Path -Parent -Path $SourceFolder
+}
+$RequiredFunctions = @(
+    Resolve-Path -Path "$SourceFolder/Private/Functions/IsInCodeBlock.ps1"
+)
+foreach ($RequiredFunction in $RequiredFunctions) {
+    . $RequiredFunction
+}
+
+#endregion RequiredFunctions
+
 function GetMDLinks {
     param(
         $mdlinks, # results from regex match
         $reflinks  # results from regex match
     )
+
+    $mdlinks = $mdlinks | Where-Object { -not (IsInCodeBlock $_.LineNumber $codefences) }
     foreach ($mdlink in $mdlinks.Matches) {
         # Skip INCLUDE and tab links
         if (-not $mdlink.Value.Trim().StartsWith('[!INCLUDE') -and
@@ -26,20 +43,19 @@ function GetMDLinks {
         }
     }
 
+    $reflinks = $reflinks | Where-Object { -not (IsInCodeBlock $_.LineNumber $codefences) }
     foreach ($reflink in $reflinks.Matches) {
-        if (-not $reflink.Value.Trim().StartsWith('[!INCLUDE')) {
-            $linkitem = [pscustomobject]([ordered]@{
-                    mdlink = ''
-                    target = ''
-                    ref    = ''
-                    label  = ''
-                })
-            switch ($reflink.Groups) {
-                { $_.Name -eq 'link' } { $linkitem.mdlink = $_.Value }
-                { $_.Name -eq 'label' } { $linkitem.label = $_.Value }
-                { $_.Name -eq 'ref' } { $linkitem.ref = $_.Value }
-            }
-            $linkitem
+        $linkitem = [pscustomobject]([ordered]@{
+                mdlink = ''
+                target = ''
+                ref    = ''
+                label  = ''
+            })
+        switch ($reflink.Groups) {
+            { $_.Name -eq 'link' } { $linkitem.mdlink = $_.Value }
+            { $_.Name -eq 'label' } { $linkitem.label = $_.Value }
+            { $_.Name -eq 'ref' } { $linkitem.ref = $_.Value }
         }
+        $linkitem
     }
 }

--- a/Projects/Modules/Documentarian/Source/Private/Functions/GetMDLinks.ps1
+++ b/Projects/Modules/Documentarian/Source/Private/Functions/GetMDLinks.ps1
@@ -18,11 +18,11 @@ foreach ($RequiredFunction in $RequiredFunctions) {
 
 function GetMDLinks {
     param(
-        $mdlinks, # results from regex match
-        $reflinks  # results from regex match
+        $mdlinks, # regex matches for [label](target)
+        $reflinks # regex matches for [label][ref]
     )
 
-    $mdlinks = $mdlinks | Where-Object { -not (IsInCodeBlock $_.LineNumber $codefences) }
+
     foreach ($mdlink in $mdlinks.Matches) {
         # Skip INCLUDE and tab links
         if (-not $mdlink.Value.Trim().StartsWith('[!INCLUDE') -and
@@ -43,7 +43,6 @@ function GetMDLinks {
         }
     }
 
-    $reflinks = $reflinks | Where-Object { -not (IsInCodeBlock $_.LineNumber $codefences) }
     foreach ($reflink in $reflinks.Matches) {
         $linkitem = [pscustomobject]([ordered]@{
                 mdlink = ''

--- a/Projects/Modules/Documentarian/Source/Private/Functions/IsInCodeBlock.ps1
+++ b/Projects/Modules/Documentarian/Source/Private/Functions/IsInCodeBlock.ps1
@@ -1,0 +1,16 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function IsInCodeBlock {
+    param(
+        $linenumber,
+        $codefences
+    )
+    foreach ($fence in $codefences) {
+        if ($linenumber -ge $fence.Start -and $linenumber -le $fence.End) {
+            return $true
+        }
+    }
+    return $false
+
+}

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Convert-MDLinks.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Convert-MDLinks.ps1
@@ -10,6 +10,7 @@ while ('Source' -ne (Split-Path -Leaf $SourceFolder)) {
 $RequiredFunctions = @(
     Resolve-Path -Path "$SourceFolder/Private/Functions/GetMDLinks.ps1"
     Resolve-Path -Path "$SourceFolder/Private/Functions/GetRefTargets.ps1"
+    Resolve-Path -Path "$SourceFolder/Private/Functions/IsInCodeBlock.ps1"
 )
 foreach ($RequiredFunction in $RequiredFunctions) {
     . $RequiredFunction
@@ -28,22 +29,27 @@ function Convert-MDLinks {
         [switch]$PassThru
     )
 
-    $mdlinkpattern = '[\s\n]*(?<link>!?\[(?<label>[^\]]*)\]\((?<target>[^\)]+)\))[\s\n]?'
-    $reflinkpattern = '[\s\n]*(?<link>!?\[(?<label>[^\]]*)\]\[(?<ref>[^\[\]]+)\])[\s\n]?'
-    $refpattern = '^(?<refdef>\[(?<ref>[^\[\]]+)\]:\s(?<target>.+))$'
+    $mdlinkpattern    = '[\s\n]*(?<link>!?\[(?<label>[^\]]*)\]\((?<target>[^\)]+)\))[\s\n]?'
+    $reflinkpattern   = '[\s\n]*(?<link>!?\[(?<label>[^\]]*)\]\[(?<ref>[^\[\]]+)\])[\s\n]?'
+    $refpattern       = '^(?<refdef>\[(?<ref>[^\[\]]+)\]:\s(?<target>.+))$'
+    $codefencepattern = '```'
 
     $Path = Get-Item $Path # resolve wildcards
+
+    $codematches = Select-String -Pattern $codefencepattern -Path $Path -AllMatches
+    $codefences = for ($x = 0; $x -lt $codematches.Count; $x+=2) {
+        [pscustomobject]@{
+            Start = $codematches[$x].LineNumber
+            End   = $codematches[$x+1].LineNumber
+        }
+    }
 
     foreach ($filename in $Path) {
         $mdfile = Get-Item $filename
 
-        $mdlinks = Get-Content $mdfile -Raw | Select-String -Pattern $mdlinkpattern -AllMatches
-        $reflinks = Get-Content $mdfile -Raw | Select-String -Pattern $reflinkpattern -AllMatches
-        $refdefs = Select-String -Path $mdfile -Pattern $refpattern -AllMatches
-
-        Write-Verbose ('{0}/{1}: {2} links' -f $mdfile.Directory.Name, $mdfile.Name, $mdlinks.Matches.count)
-        Write-Verbose ('{0}/{1}: {2} ref links' -f $mdfile.Directory.Name, $mdfile.Name, $reflinks.Matches.count)
-        Write-Verbose ('{0}/{1}: {2} ref defs' -f $mdfile.Directory.Name, $mdfile.Name, $refdefs.Matches.count)
+        $mdlinks  = Select-String -Pattern $mdlinkpattern -Path $mdfile -AllMatches
+        $reflinks = Select-String -Pattern $reflinkpattern -Path $mdfile -AllMatches
+        $refdefs  = Select-String -Path $mdfile -Pattern $refpattern -AllMatches
 
         $linkdata = GetMDLinks $mdlinks $reflinks
         $RefTargets = GetRefTargets $refdefs


### PR DESCRIPTION
# PR Summary

Before this PR `Convert-MDLinks` searched markdown for links matching the following general patterns:

- `[text](text)`
- `[text][text]`

Tthe cmdlet would replace those patterns even when those patterns were found within a fenced code block.

This PR fixes that. Now the cmdlet searches for code blocks and removes any matches that occur within them. This PR does not address the problem of a match occurring within a backticked inline code span.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I've read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [Microsoft Learn style guide for PowerShell][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/microsoft/Documentarian/blob/main/CONTRIBUTING.md
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
