### PR TITLE
Update *-Metadata cmdlet and Test-HelpInfoUri

### DIFF
--- a/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
+++ b/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
@@ -1,7 +1,7 @@
 {
   "ManifestData": {
     "Guid": "1444d8f2-6b9f-463a-aab6-beadeef7403b",
-    "ModuleVersion": "0.0.3",
+    "ModuleVersion": "0.0.4",
     "RootModule": "Documentarian.ModuleAuthor.psm1",
     "ScriptsToProcess": "",
     "VariablesToExport": "*",
@@ -28,7 +28,7 @@
   "ModuleLicenseNotice": "Licensed under the MIT License.",
   "ModuleLineEnding": "\n",
   "ModuleName": "Documentarian.ModuleAuthor",
-  "ModuleVersion": "0.0.3",
+  "ModuleVersion": "0.0.4",
   "OutputFolderPath": "./[[ManifestData.ModuleVersion]]",
   "SourceFolderPath": "./Source",
   //"SourceInitScriptPath": "",

--- a/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
@@ -25,6 +25,7 @@ release_links:
 
 ## Unreleased
 
+- Added **HelpInfoUri** parameter to `Test-HelpInfoUri` to allow testing a specific URI
 - Fixed column header name in DontShowAttributeInfo.Formats.ps1xml
 - Added PSDefaultValueAttribute to parameters in Find-ParameterWithAttribute
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Documentation/reference/cmdlets/Test-HelpInfoUri.md
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Documentation/reference/cmdlets/Test-HelpInfoUri.md
@@ -121,7 +121,7 @@ Mode                 LastWriteTime         Length Name
 ### Example 5 - Test a module by name with a custom HelpInfoUri
 
 ```powershell
-Test-HelpInfoUri -Module Microsoft.PowerShell.Utility -HelpInfoUri https://aka.ms/powershell80-help/
+Test-HelpInfoUri -Module Microsoft.PowerShell.Utility -HelpInfoUri https://aka.ms/powershell80-help
 ```
 
 ```Output

--- a/Projects/Modules/Documentarian.ModuleAuthor/Documentation/reference/cmdlets/Test-HelpInfoUri.md
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Documentation/reference/cmdlets/Test-HelpInfoUri.md
@@ -2,7 +2,7 @@
 external help file: Documentarian.ModuleAuthor-help.xml
 Locale: en-US
 Module Name: Documentarian.ModuleAuthor
-ms.date: 04/21/2023
+ms.date: 11/22/2024
 online version: https://microsoft.github.io/Documentarian/modules/moduleauthor/reference/cmdlets/test-helpinfouri
 schema: 2.0.0
 title: Test-HelpInfoUri
@@ -10,6 +10,7 @@ title: Test-HelpInfoUri
 # Test-HelpInfoUri
 
 ## SYNOPSIS
+
 Checks for the existence of the help info XML file used to update help for a module.
 
 ## SYNTAX
@@ -17,13 +18,15 @@ Checks for the existence of the help info XML file used to update help for a mod
 ### ByName (Default)
 
 ```
-Test-HelpInfoUri [-Module] <String[]> [-OutPath <String>] [<CommonParameters>]
+Test-HelpInfoUri [-Module] <string[]> [[-HelpInfoUri] <uri>] [-OutPath <string>]
+ [<CommonParameters>]
 ```
 
 ### ByObject
 
 ```
-Test-HelpInfoUri [-InputObject <Object>] [-OutPath <String>] [<CommonParameters>]
+Test-HelpInfoUri [[-HelpInfoUri] <uri>] [-InputObject <Object>] [-OutPath <string>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -115,7 +118,36 @@ Mode                 LastWriteTime         Length Name
 -a---           4/21/2023  7:10 PM            378 PSReadLine_5714753b-2afd-4492-a5fd-01d9e2cff8b5_HelpInfo.xml
 ```
 
+### Example 5 - Test a module by name with a custom HelpInfoUri
+
+```powershell
+Test-HelpInfoUri -Module Microsoft.PowerShell.Utility -HelpInfoUri https://aka.ms/powershell80-help/
+```
+
+```Output
+Module                       Code  Message
+------                       ----  -------
+Microsoft.PowerShell.Utility  404 NotFound
+```
+
 ## PARAMETERS
+
+### -HelpInfoUri
+
+The HelpInfoUri to test. If not specified, the cmdlet uses the **HelpInfoUri** property from the
+module manifest.
+
+```yaml
+Type: System.Uri
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -InputObject
 
@@ -179,7 +211,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Object
+### TestHelpInfoUriResult
 
 ## NOTES
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Test-HelpInfoUri.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Test-HelpInfoUri.ps1
@@ -10,6 +10,9 @@ function Test-HelpInfoUri {
         [Parameter(ValueFromPipeline, ParameterSetName = 'ByObject')]
         [object]$InputObject,
 
+        [Parameter(Position = 1)]
+        [uri]$HelpInfoUri,
+
         [string]$OutPath
     )
 
@@ -38,8 +41,8 @@ function Test-HelpInfoUri {
                         }
                     }
 
-                    { $_ -is [PSModuleInfo] } {
-                        $Module = $Object
+                    { $_ -is [System.Management.Automation.PSModuleInfo] } {
+                        $Module = $Object.Name
                     }
 
                     default {
@@ -63,9 +66,10 @@ function Test-HelpInfoUri {
             }
 
             $output = [pscustomobject]@{
-                Module  = $modname
-                Code    = $null
-                Message = $null
+                pstypename = 'TestHelpInfoUriResult'
+                Module     = $modname
+                Code       = $null
+                Message    = $null
             }
 
             $mod = Get-Module -Name $modname -ListAvailable | Select-Object -First 1
@@ -73,41 +77,57 @@ function Test-HelpInfoUri {
             # If the input wasn't a module, return the failed result immediately
             if ($null -eq $mod) {
                 $output.Message = 'Module not found'
-                $output.Code = 0x2
+                $output.Code    = 0x2
                 $output
                 continue
             }
 
-            # If the input was a module, we have the component parts needed to check it
-            Write-Verbose "$($mod.Name) - $($mod.Guid) - $($mod.HelpInfoUri)"
+            # else we have a module object
             $output.Module = $mod.Name
 
-            # If the module doesn't have a HelpInfoUri, we know it can't be reached
-            if ($null -eq $mod.HelpInfoUri) {
+            # The HelpInfoUri parameter overrides $mod.HelpInfoUri, allowing you to test a new URI
+            # before updating the module. If the parameter is empty, $mod.HelpInfoUri.
+            if ($HelpInfoUri -eq '') {
+                $HelpInfoUri = $mod.HelpInfoUri
+            }
+
+            # If the input was a module, we have the component parts needed to check it
+            Write-Verbose "$($mod.Name) - $($mod.Guid) - $HelpInfoUri"
+
+            # If $HelpInfoUri is empty, we know it can't be reached
+            if ($null -eq $HelpInfoUri) {
                 $output.Message = 'HelpInfoUri is null or empty'
-                $output.Code = 0x0000138f
+                $output.Code    = 0x00002ef8 # ERROR_INTERNET_NO_CONTEXT
+                $output
+                continue
+            }
+
+            # The $HelpInfoUri must end with a slash to be valid for Update-Help
+            if ($HelpInfoUri.OriginalString[-1] -ne '/') {
+                $output.Message = 'HelpInfoUri must end in a slash (/)'
+                $output.Code    = 0x00002efb # ERROR_INTERNET_INCORRECT_FORMAT
                 $output
                 continue
             }
 
             # Resolve the URI from the manifest, which may include redirection.
             try {
-                # If successful, then the URI probably points to a browsable directory
-                $response = Invoke-WebRequest -Uri $mod.HelpInfoUri -ErrorAction Stop
+                # If successful, then the URI probably points to a browseable directory
+                $response = Invoke-WebRequest -Uri $HelpInfoUri -ErrorAction Stop
                 continue
             } catch {
-                if ($_.Exception.Response.StatusCode.value__ -ne 404) {
-                    # If the response is anything other than 404, then the URI is probably invalid
-                    $output.Code = $_.Exception.Response.StatusCode.value__
-                    $output.Message = $_.Exception.Response.StatusCode
-                    $output
-                    continue
-                } else {
+                if ($_.Exception.Response.StatusCode.value__ -eq 404) {
                     # If the response is 404, then the URI is probably valid, especially when
                     # hosted in an Azure blobstore. You can't browse to the URI, but you can
                     # download the file using a fully qualified URI to the file. A true 404 problem
                     # will be caught later.
                     $baseUri = $_.TargetObject.RequestUri.AbsoluteUri
+                } else {
+                    # If the response is anything other than 404, then the URI is probably invalid
+                    $output.Message = $_.Exception.Response.StatusCode
+                    $output.Code    = $_.Exception.Response.StatusCode.value__
+                    $output
+                    continue
                 }
             }
 
@@ -123,6 +143,7 @@ function Test-HelpInfoUri {
                     ErrorAction = 'Stop'
                 }
                 if ($OutPath) {
+                    # Add the OutFile parameter to Invoke-WebRequest if an output path is specified
                     $params.Add(
                         'OutFile',
                         (Join-Path -Path $OutPath -ChildPath $HelpInfoUri.Segments[-1])

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Test-HelpInfoUri.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Test-HelpInfoUri.ps1
@@ -87,7 +87,7 @@ function Test-HelpInfoUri {
 
             # The HelpInfoUri parameter overrides $mod.HelpInfoUri, allowing you to test a new URI
             # before updating the module. If the parameter is empty, $mod.HelpInfoUri.
-            if ($HelpInfoUri -eq '') {
+            if ( $PSBoundParameters.Keys -notcontains 'HelpInfoUri') {
                 $HelpInfoUri = $mod.HelpInfoUri
             }
 
@@ -98,14 +98,6 @@ function Test-HelpInfoUri {
             if ($null -eq $HelpInfoUri) {
                 $output.Message = 'HelpInfoUri is null or empty'
                 $output.Code    = 0x00002ef8 # ERROR_INTERNET_NO_CONTEXT
-                $output
-                continue
-            }
-
-            # The $HelpInfoUri must end with a slash to be valid for Update-Help
-            if ($HelpInfoUri.OriginalString[-1] -ne '/') {
-                $output.Message = 'HelpInfoUri must end in a slash (/)'
-                $output.Code    = 0x00002efb # ERROR_INTERNET_INCORRECT_FORMAT
                 $output
                 continue
             }

--- a/Projects/Modules/Documentarian/.DevX.jsonc
+++ b/Projects/Modules/Documentarian/.DevX.jsonc
@@ -2,7 +2,7 @@
 {
   "ManifestData": {
     "RootModule": "Documentarian.psm1",
-    "ModuleVersion": "0.0.2",
+    "ModuleVersion": "0.0.3",
     "CompatiblePSEditions": "Core",
     "GUID": "2422ec90-815c-4c1d-8ec1-4c9b082f2909",
     "Author": "PowerShell Docs Team",

--- a/Projects/Modules/Documentarian/CHANGELOG.md
+++ b/Projects/Modules/Documentarian/CHANGELOG.md
@@ -25,6 +25,9 @@ release_links:
 
 ## Unreleased
 
+- Updated `*-Metadata` cmdlets to use `Get-Document` to parse the content of markdown files
+- Added **AsJson** parameter to `Get-Metadata` to output the results as a JSON object
+
 Related Links
 : {{< changelog/link/prs after="2023-03-27" >}}
 

--- a/Projects/Modules/Documentarian/Documentation/reference/cmdlets/Get-Metadata.md
+++ b/Projects/Modules/Documentarian/Documentation/reference/cmdlets/Get-Metadata.md
@@ -10,6 +10,7 @@ title: Get-Metadata
 # Get-Metadata
 
 ## SYNOPSIS
+
 Get the metadata frontmatter from a Markdown file.
 
 ## SYNTAX
@@ -30,6 +31,12 @@ Get-Metadata [-Path] <string> -AsObject [-Recurse] [<CommonParameters>]
 
 ```
 Get-Metadata [-Path] <string> -AsYaml [-Recurse] [<CommonParameters>]
+```
+
+### AsJson
+
+```
+Get-Metadata [-Path] <string> -AsJson [-Recurse] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -74,20 +81,21 @@ Get-Metadata .\install\Installing-PowerShell-on-Windows.md -AsYaml
 
 ```Output
 description: Information about installing PowerShell on Windows
-ms.date: 01/09/2023
+ms.date: 11/22/2024
 title: Installing PowerShell on Windows
 ```
 
 ## PARAMETERS
 
+### -AsJson
+
 ### -AsObject
 
-Returns the metadata as a **PSObject**. Unlike the hashtable, the object includes the original file
-path as a property.
+Returns the metadata as a JSON object.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
-Parameter Sets: AsObject
+Parameter Sets: AsJson
 Aliases:
 
 Required: True

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-Metadata.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-Metadata.ps1
@@ -6,10 +6,14 @@ function Get-Metadata {
     [CmdletBinding(DefaultParameterSetName = 'AsHash')]
     param(
         [Parameter(ParameterSetName = 'AsHash', Mandatory, Position = 0)]
+        [Parameter(ParameterSetName = 'AsJson', Mandatory, Position = 0)]
         [Parameter(ParameterSetName = 'AsObject', Mandatory, Position = 0)]
         [Parameter(ParameterSetName = 'AsYaml', Mandatory, Position = 0)]
         [SupportsWildcards()]
         [string]$Path,
+
+        [Parameter(ParameterSetName = 'AsJson', Mandatory)]
+        [switch]$AsJson,
 
         [Parameter(ParameterSetName = 'AsObject', Mandatory)]
         [switch]$AsObject,
@@ -18,53 +22,22 @@ function Get-Metadata {
         [switch]$AsYaml,
 
         [Parameter(ParameterSetName = 'AsHash')]
+        [Parameter(ParameterSetName = 'AsJson')]
         [Parameter(ParameterSetName = 'AsObject')]
         [Parameter(ParameterSetName = 'AsYaml')]
         [switch]$Recurse
     )
 
     foreach ($file in (Get-ChildItem -Recurse:$Recurse -File -Path $Path)) {
-        $ignorelist = 'keywords', 'helpviewer_keywords', 'ms.assetid'
-        $lines = Get-YamlHeader $file
-
-        if ($AsYaml) {
-            $lines
+        $doc = Get-Document -Path $file.FullName
+        if ($AsObject) {
+            [pscustomobject]$doc.FrontMatter
+        } elseif ($AsJson) {
+            $doc.FrontMatter | ConvertTo-Json
+        } elseif ($AsYaml) {
+            $doc.FrontMatter | YaYaml\ConvertTo-Yaml
         } else {
-            $meta = @{}
-            foreach ($line in $lines) {
-                ### Parse the YAML block
-                ### This is a naive implementation that only works for simple single-line
-                ### YAML data types and has some special cases for the metadata we care
-                ### about. It's not intended to be a general purpose solution.
-                $i = $line.IndexOf(':')
-                if ($i -ne -1) {
-                    $key = $line.Substring(0, $i)
-                    if (!$ignorelist.Contains($key)) {
-                        $value = $line.Substring($i + 1).replace('"', '')
-                        switch ($key) {
-                            'title' {
-                                $value = $value.split('|')[0].Trim()
-                            }
-                            'ms.date' {
-                                [datetime]$date = $value.Trim()
-                                $value = Get-Date $date -Format 'MM/dd/yyyy'
-                            }
-                            Default {
-                                $value = $value.Trim()
-                            }
-                        }
-
-                        $meta.Add($key, $value)
-                    }
-                }
-            }
-            if ($AsObject) {
-                $meta.Add('file', $file.FullName)
-                [pscustomobject]$meta
-            } else {
-                $meta
-            }
+            $doc.FrontMatter
         }
     }
-
 }

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Remove-Metadata.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Remove-Metadata.ps1
@@ -15,18 +15,24 @@ function Remove-Metadata {
     )
 
     foreach ($file in (Get-ChildItem -Path $Path -Recurse:$Recurse)) {
-        $file.name
-        $metadata = Get-Metadata -Path $file
-        $mdtext = Get-ContentWithoutHeader -Path $file
+
+        $doc = Get-Document -Path $file
 
         foreach ($key in $KeyName) {
-            if ($metadata.ContainsKey($key)) {
+            if ($doc.FrontMatter.ContainsKey($key)) {
                 $metadata.Remove($key)
             }
         }
-
-        Set-Content -Value (hash2yaml $metadata) -Path $file -Force -Encoding utf8
-        Add-Content -Value $mdtext -Path $file -Encoding utf8
+        $header = @(
+            '---'
+            [environment]::NewLine
+            $doc.FrontMatter | ConvertTo-Yaml
+            [environment]::NewLine
+            '---'
+        ) -join ''
+        Set-Content -Value $header  -Path $file -Force -Encoding utf8
+        Add-Content -Value $doc.Body -Path $file -Encoding utf8
+        $file
     }
 
 }

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Set-Metadata.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Set-Metadata.ps1
@@ -15,10 +15,16 @@ function Set-Metadata {
     )
 
     foreach ($file in (Get-ChildItem -Path $Path -Recurse:$Recurse)) {
-        $file.Name
-        $mdtext = Get-ContentWithoutHeader -Path $file
-        Set-Content -Value (hash2yaml $NewMetadata) -Path $file -Force -Encoding utf8
-        Add-Content -Value $mdtext -Path $file -Encoding utf8
+        $header = @(
+            '---'
+            [environment]::NewLine
+            $NewMetadata | ConvertTo-Yaml
+            [environment]::NewLine
+            '---'
+        ) -join ''
+        Set-Content -Value $header  -Path $file -Force -Encoding utf8
+        Add-Content -Value $doc.Body -Path $file -Encoding utf8
+        $file
     }
 
 }

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Update-Metadata.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Update-Metadata.ps1
@@ -15,9 +15,8 @@ function Update-Metadata {
     )
 
     foreach ($file in (Get-ChildItem -Path $Path -Recurse:$Recurse)) {
-        $file.name
-        $OldMetadata = Get-Metadata -Path $file
-        $mdtext = Get-ContentWithoutHeader -Path $file
+        $doc = Get-Document -Path $file
+        $OldMetadata = $doc.FrontMatter
 
         $update = $OldMetadata.Clone()
         foreach ($key in $NewMetadata.Keys) {
@@ -28,8 +27,16 @@ function Update-Metadata {
             }
         }
 
-        Set-Content -Value (hash2yaml $update) -Path $file -Force -Encoding utf8
-        Add-Content -Value $mdtext -Path $file -Encoding utf8
+        $header = @(
+            '---'
+            [environment]::NewLine
+            $update | ConvertTo-Yaml
+            [environment]::NewLine
+            '---'
+        ) -join ''
+        Set-Content -Value $header  -Path $file -Force -Encoding utf8
+        Add-Content -Value $doc.Body -Path $file -Encoding utf8
+        $file
     }
 
 }


### PR DESCRIPTION
# PR Summary

- Before this PR, the `*-Metadata` cmdlets did a naive parse of the metadata to isolate the frontmatter metadata. This PR changes the code to use `Get-Document` to parse the markdown and return the body and the frontmatter as properties of an object.
- Adds the **AsJson** parameter to `Get-Metadata` so that you can get the metadata as a JSON object.
- Add the **HelpInfoUri** parameter to `Test-HelpInfoUri` so you can override the **HelpInfoUri** property of a module. This allows you to test a new **HelpInfoUri** before changing the module manifest.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I've read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [Microsoft Learn style guide for PowerShell][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://github.com/microsoft/Documentarian/blob/main/CONTRIBUTING.md
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
