### PR TITLE
Use latest stable version of PSRule

### DIFF
--- a/.github/workflows/rules.github.yaml
+++ b/.github/workflows/rules.github.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run PSRule analysis
-        uses: Microsoft/ps-rule@main
+        uses: microsoft/ps-rule@v2.9.0
         with:
           modules: "PSRule.Rules.MSFT.OSS"
           prerelease: true


### PR DESCRIPTION
# PR Summary

- Switch to using the latest stable version of PSRule in CI pipeline.

---

👋 Hi, we're making changes the `microsoft/ps-rule` action preparing for the next major release which will introduce breaking changes.

We noticed that you are using an unpinned configuration `@main` which is not recommended. Please feel free to close this PR if this is intended, however note your pipeline may be broken by upcoming changes.

For recommendations on how to pin to a specific version, see the [documentation](https://github.com/microsoft/ps-rule).