### PR TITLE
Update Get-ContentWithoutHeader and Invoke-Pandoc

### DIFF
--- a/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
+++ b/Projects/Modules/Documentarian.ModuleAuthor/.DevX.jsonc
@@ -1,7 +1,7 @@
 {
   "ManifestData": {
     "Guid": "1444d8f2-6b9f-463a-aab6-beadeef7403b",
-    "ModuleVersion": "0.0.5",
+    "ModuleVersion": "0.0.6",
     "RootModule": "Documentarian.ModuleAuthor.psm1",
     "ScriptsToProcess": "",
     "VariablesToExport": "*",

--- a/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
@@ -37,8 +37,6 @@ Related Links
 
 - Refactored `Invoke-Pandoc` to create the header required by `Get-Help` to display the help
   metadata correctly. Also added error handling to provide better feedback when Pandoc fails.
-- Added private function `WrapText` to format long text into multiple lines with a specified
-  indentation.
 - Update `Get-ParameterInfo` and `Find-ParameterWithAttribute` to support three more parameter
   attributes:
 

--- a/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
+++ b/Projects/Modules/Documentarian.ModuleAuthor/CHANGELOG.md
@@ -35,6 +35,10 @@ Related Links
 
 ### Added
 
+- Refactored `Invoke-Pandoc` to create the header required by `Get-Help` to display the help
+  metadata correctly. Also added error handling to provide better feedback when Pandoc fails.
+- Added private function `WrapText` to format long text into multiple lines with a specified
+  indentation.
 - Update `Get-ParameterInfo` and `Find-ParameterWithAttribute` to support three more parameter
   attributes:
 
@@ -48,6 +52,7 @@ Related Links
 
 ### Fixed
 
+- Fixed logic of how `Get-ContentWithoutHeader` finds the end of the YAML front matter.
 - Corrected the behavior for [`Get-ParameterInfo`] for parameters that belong to multiple parameter
   sets. Previously, the `Accept pipeline input` key wrote invalid metadata. Now, the metadata is
   valid.

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Private/Functions/Wrap/WrapText.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Private/Functions/Wrap/WrapText.ps1
@@ -1,0 +1,41 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+<#
+.SYNOPSIS
+Wraps text to a specified line length.
+
+.DESCRIPTION
+Wraps text to a specified line length. Useful for formatting descriptions in
+markdown files.
+
+.PARAMETER line
+The line of text to wrap.
+
+.PARAMETER pad
+The number of spaces to indent wrapped lines. Default is 0.
+
+.PARAMETER max
+The maximum line length. Default is 79.
+#>
+function WrapText {
+    param(
+        [string]$line,
+        [uint]$pad = 0,
+        [uint]$max = 79
+    )
+    $lines = @()
+    [string[]]$parts = $line -split ' '
+    [string]$newLine = ' ' * $pad
+    foreach ($p in $parts) {
+        if ($newLine.Length + $p.Length + 1 -lt $max) {
+            $newLine += "$p "
+        } else {
+            $lines += $newLine.TrimEnd(' ')
+            $newLine = ' ' * $pad + "$p "
+        }
+    }
+    if ($newLine.Trim() -ne '') {
+        $lines += $newLine.TrimEnd(' ')
+    }
+    $lines
+}

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Invoke-Pandoc.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Invoke-Pandoc.ps1
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 
 function Invoke-Pandoc {
+    [CmdletBinding()]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory)]
         [string[]]$Path,

--- a/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Invoke-Pandoc.ps1
+++ b/Projects/Modules/Documentarian.ModuleAuthor/Source/Public/Functions/Invoke-Pandoc.ps1
@@ -2,24 +2,73 @@
 # Licensed under the MIT License.
 
 function Invoke-Pandoc {
-
     param(
         [Parameter(Mandatory)]
         [string[]]$Path,
         [string]$OutputPath = '.',
         [switch]$Recurse
     )
-    $pandocExe = 'C:\Program Files\Pandoc\pandoc.exe'
-    Get-ChildItem $Path -Recurse:$Recurse | ForEach-Object {
-        $outfile = Join-Path $OutputPath "$($_.BaseName).help.txt"
-        $pandocArgs = @(
-            '--from=gfm',
-            '--to=plain+multiline_tables',
-            '--columns=79',
-            "--output=$outfile",
-            '--quiet'
+    $pandocExe = Get-Command pandoc.exe # Find pandoc in PATH
+    if ($null -eq $pandocExe) {
+        Write-Error 'pandoc.exe not found in PATH. See https://pandoc.org/installing.html'
+        return
+    }
+    $pandocArgs = @(
+        '--from=gfm',
+        '--to=plain+multiline_tables',
+        '--columns=79',
+        '--quiet'
+    )
+
+    if (-not $PSBoundParameters.ContainsKey('Recurse')) {
+        $Recurse = $false
+    }
+
+    $files = Get-ChildItem $Path -Recurse:$Recurse
+    foreach ($f in $files) {
+        $outfile = Join-Path $OutputPath "$($f.BaseName).help.txt"
+        Write-Verbose "Converting $($f.Name) to $outfile"
+
+        $metadata = Get-Metadata -Path $f
+        # Write error and skip if no metadata or no title
+        if ($null -eq $metadata) {
+            Write-Error "No metadata found in $($f.Name)"
+            continue
+        }
+        if (-not $metadata.Contains('title') -or $metadata.title -eq '') {
+            Write-Error "Missing metadata.title in $($f.Name)"
+            continue
+        }
+
+        $markdown = Get-Content $f
+
+        # Find the short description block and opening lines of the article
+        if ($metadata.title -like '*provider') {
+            $firstSection = Select-String -Pattern '^## Provider name$' -Path $f
+            $startLine = $firstSection[0].LineNumber - 1
+            $pattern = '^## (Short|Detailed) Description$'
+            $shortBlock = Select-String -Pattern $pattern -Path $f
+            $begin = $shortBlock[0].LineNumber
+            $end = $shortBlock[1].LineNumber - 2
+            $shortDescription = ($markdown[$begin..$end] -join ' ').Trim()
+        } else {
+            $pattern = '^## (Short|Long) Description$'
+            $shortBlock = Select-String -Pattern $pattern -Path $f
+            $begin = $shortBlock[0].LineNumber
+            $end = $shortBlock[1].LineNumber - 2
+            $shortDescription = ($markdown[$begin..$end] -join ' ').Trim()
+            $startLine = $shortBlock[1].LineNumber - 1
+        }
+
+        $about = $markdown[$startLine..($markdown.Count - 1)] | & $pandocExe @pandocArgs
+        $header = @(
+            'TOPIC'
+            WrapText -line $metadata.title -pad 4
+            ''
+            'SHORT DESCRIPTION'
+            WrapText -line $shortDescription -pad 4
+            ''
         )
-        Get-ContentWithoutHeader $_ | & $pandocExe $pandocArgs
-        Get-ChildItem $outfile
+        $header, $about | Out-File $outfile -Encoding utf8
     }
 }

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-ContentWithoutHeader.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-ContentWithoutHeader.ps1
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 function Get-ContentWithoutHeader {
-
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, Position = 0)]
@@ -11,12 +10,15 @@ function Get-ContentWithoutHeader {
 
     $doc = Get-Content $path -Encoding UTF8
     $hasFrontmatter = Select-String -Pattern '^---$' -Path $path
-    $start = 0
-    $end = $doc.count
+    if ($hasFrontmatter.Count -gt 1) {
+        $start = 0
+        $end = $doc.count
 
-    if ($hasFrontmatter) {
-        $start = $hasFrontmatter[-1].LineNumber
+        if ($hasFrontmatter) {
+            $start = $hasFrontmatter[1].LineNumber
+        }
+        $doc[$start..$end]
+    } else {
+        Write-Error "Invalid frontmatter in $Path"
     }
-    $doc[$start..$end]
-
 }

--- a/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-ContentWithoutHeader.ps1
+++ b/Projects/Modules/Documentarian/Source/Public/Functions/General/Get-ContentWithoutHeader.ps1
@@ -3,6 +3,7 @@
 
 function Get-ContentWithoutHeader {
     [CmdletBinding()]
+    [OutputType([string[]])]
     param(
         [Parameter(Mandatory, Position = 0)]
         [string]$Path


### PR DESCRIPTION
- Refactored `Invoke-Pandoc` to create the header required by `Get-Help` to display the help metadata correctly. Also added error handling to provide better feedback when Pandoc fails.
- Added private function `WrapText` to format long text into multiple lines with a specified indentation.
- Fixed logic of how `Get-ContentWithoutHeader` finds the end of the YAML front matter.  

